### PR TITLE
[Feature] Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 100


### PR DESCRIPTION
Just added dependabot.yml, which runs every month, and should inform of which packages can be updated.

It uses uv, so any updates suggested should preserve compatability between all packages, offering bug fixes and performance improvements from downstream. But it may lead to a few extra PRs of packages that the library has not incorporated breaking changes for.

Relies on #2 being implemented.