### PR TITLE
[Feature] MARL: Add 5 matrix environments

### DIFF
--- a/masa/envs/multiagent/matrix/bertrand.py
+++ b/masa/envs/multiagent/matrix/bertrand.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import functools
+from enum import IntEnum
+
+import numpy as np
+from gymnasium.spaces import Box, Discrete
+from pettingzoo import ParallelEnv
+
+class Actions(IntEnum):
+    High = 0    # Collusive/high price
+    Low  = 1    # Undercut/low price
+
+class BertrandMatrix(ParallelEnv):
+    """
+    Repeated 2-player Bertrand (Parallel PettingZoo)
+
+    Stage game (Row vs Column) with payoffs:
+        - High   vs Low : (S, T)
+        - Low    vs High: (T, S)
+        - High   vs High: (R, R)
+        - Low    vs Low : (P, P)  # price war
+
+    Defaults: T=8, R=5, S=0, P=0 (all floats).
+
+    Observations (global, binary channels), shape is either (C,) if flattened or (1,1,C):
+      For each agent i in {0,1}:
+        - ch 2*i + 0 = 1 if agent_i's last action was High, else 0
+        - ch 2*i + 1 = 1 if agent_i's last action was Low, else 0
+      Plus:
+        - ch 2*num_agents = 1 if last outcome was a price war (both Low), else 0
+
+      On the first round (after reset), all channels are 0.
+    """
+
+    metadata = {"name": "bertrand_matrix_v0", "render_modes": ["human", "rgb_array"]}
+
+    def __init__(
+        self,
+        *,
+        num_agents: int = 2,
+        max_moves: int = 200,
+        T: float = 8.0,
+        R: float = 5.0,
+        S: float = 0.0,
+        P: float = 0.0,
+        flatten_observations: bool = True,
+        render_mode=None,
+        seed: int | None = None,
+    ):
+        assert num_agents == 2, "BertrandMatrix currently supports exactly 2 agents."
+        self.n_agents = int(num_agents)
+        self.possible_agents = [f"player_{i}" for i in range(self.n_agents)]
+
+        # Payoffs
+        self.T, self.R, self.S, self.P = float(T), float(R), float(S), float(P)
+
+        # Repetition horizon
+        self.max_moves = int(max_moves)
+
+        # Observation config (1x1xC binary channels, optionally flattened)
+        # C = 2*num_agents + 1 (two action-bits per agent + 1 war bit)
+        self.n_obs_types = 2 * self.n_agents + 1
+        self.flatten_observations = bool(flatten_observations)
+
+        # RNG (not strictly needed; kept for parity)
+        self.rng = np.random.RandomState(0 if seed is None else seed)
+
+        # Runtime state
+        self.agents: list[str] = []
+        self._round = 0
+        self._last_actions: dict[str, int | None] = {}  # Actions.{High,Low} or None
+        self._last_war: bool = False
+
+        # rendering-relevant runtime state
+        self.render_mode = render_mode
+        self._renderer = None
+        # self._renderer: BertrandRenderer | None = None
+        # if self.render_mode is not None:
+        #     self._renderer = BertrandRenderer(self.render_mode)
+        self._cum_rewards: dict[str, float] = {}
+
+        # Spaces
+        self.observation_spaces = {a: self.observation_space(a) for a in self.possible_agents}
+        self.action_spaces = {a: self.action_space(a) for a in self.possible_agents}
+
+    # ─────────────────────────── PettingZoo API ───────────────────────────
+    @functools.lru_cache(maxsize=None)
+    def observation_space(self, agent):
+        C = self.n_obs_types
+        if self.flatten_observations:
+            return Box(low=0, high=1, shape=(C,), dtype=np.uint8)
+        return Box(low=0, high=1, shape=(1, 1, C), dtype=np.uint8)
+
+    @functools.lru_cache(maxsize=None)
+    def action_space(self, agent):
+        # 0 = High, 1 = Low
+        return Discrete(2)
+
+    def reset(self, seed: int | None = None, options: dict | None = None):
+        if seed is not None:
+            self.rng = np.random.RandomState(seed)
+
+        self.agents = self.possible_agents[:]
+        self._round = 0
+        self._last_actions = {a: None for a in self.agents}
+        self._last_war = False
+        self._cum_rewards = {a: 0.0 for a in self.agents}
+
+        obs = {a: self._obs() for a in self.agents}
+        infos = {a: {"round": self._round, "last_actions": None, "war": False} for a in self.agents}
+        return obs, infos
+
+    def step(self, actions: dict[str, int]):
+        if not actions:
+            self.agents = []
+            return {}, {}, {}, {}, {}
+
+        # Only two agents supported
+        a0, a1 = self.possible_agents
+        act0 = int(actions.get(a0, Actions.High))
+        act1 = int(actions.get(a1, Actions.High))
+
+        # Stage payoffs (Bertrand):
+        # (High,High)->(R,R); (High,Low)->(S,T); (Low,High)->(T,S); (Low,Low)->(P,P, war)
+        if act0 == Actions.High and act1 == Actions.High:
+            r0, r1 = self.R, self.R
+            self._last_war = False
+            outcome = "High-High"
+        elif act0 == Actions.High and act1 == Actions.Low:
+            r0, r1 = self.S, self.T
+            self._last_war = False
+            outcome = "High-Low"
+        elif act0 == Actions.Low and act1 == Actions.High:
+            r0, r1 = self.T, self.S
+            self._last_war = False
+            outcome = "Low-High"
+        else:  # Low-Low
+            r0, r1 = self.P, self.P
+            self._last_war = True
+            outcome = "Low-Low"
+
+        rewards = {a0: float(r0), a1: float(r1)}
+
+        # Update last actions for observation
+        self._last_actions[a0] = act0
+        self._last_actions[a1] = act1
+        self._cum_rewards[a0] += r0
+        self._cum_rewards[a1] += r1
+
+        # Time & termination
+        self._round += 1
+        env_trunc = self._round >= self.max_moves
+
+        terminations = {a0: False, a1: False}
+        truncations = {a0: env_trunc, a1: env_trunc}
+        infos = {
+            a0: {"round": self._round, "last_actions": (act0, act1), "outcome": outcome, "war": self._last_war},
+            a1: {"round": self._round, "last_actions": (act1, act0), "outcome": outcome, "war": self._last_war},
+        }
+
+        obs = {a: self._obs() for a in self.agents}
+        if env_trunc:
+            for a in self.agents:
+                truncations[a] = True
+            self.agents = []
+
+        if self.render_mode in ("human", "rgb_array"):
+            self.render()
+
+        return obs, rewards, terminations, truncations, infos
+
+    def render(self):
+        if self.render_mode is None:
+            return
+        if not self._renderer:
+            raise ValueError("Renderer missing; create env with render_mode='human' or 'rgb_array'.")
+
+        pay = {"T": self.T, "R": self.R, "S": self.S, "P": self.P}
+        last = (self._last_actions.get("player_0"), self._last_actions.get("player_1"))
+
+        frame = self._renderer.render(
+            round_no=self._round,
+            last_actions=last,
+            last_war=self._last_war,
+            cum_rewards=self._cum_rewards,
+            payoffs=pay,
+        )
+        return frame
+
+    def close(self):
+        if self._renderer:
+            self._renderer.close()
+
+    # ───────────────────────────── Internals ─────────────────────────────
+    def _obs(self):
+        """
+        Binary channels, either (C,) or (1,1,C):
+          ch0 = p0 High, ch1 = p0 Low,
+          ch2 = p1 High, ch3 = p1 Low,
+          ch4 = war flag (both Low)
+        """
+        C = self.n_obs_types
+        v = np.zeros((C,), dtype=np.uint8)
+
+        def set_bits(pid: str, base: int):
+            a = self._last_actions.get(pid, None)
+            if a is None:
+                return
+            if a == Actions.High:
+                v[base + 0] = 1
+            elif a == Actions.Low:
+                v[base + 1] = 1
+
+        set_bits("player_0", 0)
+        set_bits("player_1", 2)
+        v[2 * self.n_agents] = 1 if self._last_war else 0
+
+        if self.flatten_observations:
+            return v
+        return v.reshape(1, 1, -1)
+
+    # ────────────────────────────────────────────────────────────────────
+    #                          State helpers
+    # ────────────────────────────────────────────────────────────────────
+    @property
+    def state_space(self):
+        C = self.n_obs_types
+        if self.flatten_observations:
+            return Box(low=0, high=1, shape=(C,), dtype=np.uint8)
+        return Box(low=0, high=1, shape=(1, 1, C), dtype=np.uint8)
+
+    def state(self):
+        return self._obs()
+
+    def num_cells(self) -> int:
+        """Number of spatial cells in the layered observation grid.
+
+        BertrandMatrix is non-spatial: the entire game state is a single global cell.
+        This returns 1 regardless of whether observations are flattened or shaped (1, 1, C).
+        """
+        return 1
+
+    def channel_names(self) -> list[str]:
+        """
+        Human-friendly names for each observation channel index.
+
+        Index i of the returned list corresponds to channel i in the
+        observation vector (or the last axis of the (1, 1, C) tensor).
+        """
+        names: list[str] = ["" for _ in range(self.n_obs_types)]
+
+        # Per-agent action bits: (High, Low)
+        for i in range(self.n_agents):
+            hi_idx = 2 * i
+            lo_idx = 2 * i + 1
+            if hi_idx < self.n_obs_types:
+                names[hi_idx] = f"player_{i}_high"
+            if lo_idx < self.n_obs_types:
+                names[lo_idx] = f"player_{i}_low"
+
+        # Price war flag
+        war_idx = 2 * self.n_agents
+        if war_idx < self.n_obs_types:
+            names[war_idx] = "price_war"
+
+        # Fallback for any unnamed channels (future-proofing)
+        for i, name in enumerate(names):
+            if not name:
+                names[i] = f"channel_{i}"
+
+        return names
+
+    def action_names(self, action: int) -> str:
+        """
+        Human-friendly name for an action integer ID.
+        """
+        try:
+            name = Actions(int(action)).name
+        except ValueError:
+            return f"action_{action}"
+        return "".join(
+            f"_{ch.lower()}" if ch.isupper() and i > 0 else ch.lower()
+            for i, ch in enumerate(name)
+        )
+
+    # ────────────────────────────────────────────────────────────────────
+    #               Lightweight state serialization
+    # ────────────────────────────────────────────────────────────────────
+    def get_state(self):
+        """
+        Fully restorable snapshot (no deep clone).
+
+        Tuple layout:
+          (
+            agents: tuple[str, ...],
+            round_no: int,
+            last_actions: tuple[int|None, int|None],  # (player_0, player_1)
+            last_war: bool,
+            cum_rewards: tuple[float, float],         # (player_0, player_1)
+            rng_state: object                         # np.random.RandomState.get_state()
+          )
+        """
+        agents = tuple(self.agents) if getattr(self, "agents", None) is not None else tuple()
+
+        p0, p1 = self.possible_agents
+        last_actions = (self._last_actions.get(p0, None), self._last_actions.get(p1, None))
+        cum_rewards = (float(self._cum_rewards.get(p0, 0.0)), float(self._cum_rewards.get(p1, 0.0)))
+
+        rng_state = self.rng.get_state()
+        return (
+            agents,
+            int(self._round),
+            last_actions,
+            bool(self._last_war),
+            cum_rewards,
+            rng_state,
+        )
+
+    def set_state(self, state):
+        """
+        Restore a snapshot produced by get_state().
+        """
+        (
+            agents,
+            round_no,
+            last_actions,
+            last_war,
+            cum_rewards,
+            rng_state,
+        ) = state
+
+        self.agents = list(agents)
+        self._round = int(round_no)
+
+        p0, p1 = self.possible_agents
+
+        if len(last_actions) != 2:
+            raise ValueError(f"BertrandMatrix.set_state: last_actions must be len 2, got {len(last_actions)}")
+        if len(cum_rewards) != 2:
+            raise ValueError(f"BertrandMatrix.set_state: cum_rewards must be len 2, got {len(cum_rewards)}")
+
+        self._last_actions = {
+            p0: (None if last_actions[0] is None else int(last_actions[0])),
+            p1: (None if last_actions[1] is None else int(last_actions[1])),
+        }
+        self._last_war = bool(last_war)
+
+        self._cum_rewards = {
+            p0: float(cum_rewards[0]),
+            p1: float(cum_rewards[1]),
+        }
+
+        if rng_state is not None:
+            self.rng.set_state(rng_state)
+
+    def get_rng_state(self):
+        return self.rng.get_state()
+
+    def set_rng_state(self, rng_state):
+        self.rng.set_state(rng_state)
+
+    def reseed(self, seed: int):
+        self.rng = np.random.RandomState(int(seed))

--- a/masa/envs/multiagent/matrix/chicken.py
+++ b/masa/envs/multiagent/matrix/chicken.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import functools
+from enum import IntEnum
+
+import numpy as np
+from gymnasium.spaces import Box, Discrete
+from pettingzoo import ParallelEnv
+
+class Actions(IntEnum):
+    Swerve   = 0
+    Straight = 1
+
+class ChickenMatrix(ParallelEnv):
+    """
+    Repeated 2-player Chicken (Parallel PettingZoo)
+
+    Stage game (Row vs Column) with payoffs:
+        - Straight vs Swerve: (T, S)
+        - Swerve  vs Straight: (S, T)
+        - Swerve  vs Swerve:   (R, R)
+        - Straight vs Straight:(P, P)  # crash
+
+    Defaults: T=3, R=2, S=1, P=0 (all floats).
+
+    Observations (global, binary channels), shape is either (C,) if flattened or (1,1,C):
+      For each agent i in {0,1}:
+        - ch 2*i + 0 = 1 if agent_i's last action was Swerve, else 0
+        - ch 2*i + 1 = 1 if agent_i's last action was Straight, else 0
+      Plus:
+        - ch 2*num_agents = 1 if last outcome was a crash (both Straight), else 0
+
+      On the first round (after reset), all channels are 0.
+    """
+
+    metadata = {"name": "chicken_matrix_v0", "render_modes": ["human", "rgb_array"]}
+
+    def __init__(
+        self,
+        *,
+        num_agents: int = 2,
+        max_moves: int = 200,
+        T: float = 3.0,
+        R: float = 2.0,
+        S: float = 1.0,
+        P: float = 0.0,
+        flatten_observations: bool = True,
+        render_mode=None,
+        seed: int | None = None,
+    ):
+        assert num_agents == 2, "ChickenMatrix currently supports exactly 2 agents."
+        self.n_agents = int(num_agents)
+        self.possible_agents = [f"player_{i}" for i in range(self.n_agents)]
+
+        # Payoffs
+        self.T, self.R, self.S, self.P = float(T), float(R), float(S), float(P)
+
+        # Repetition horizon
+        self.max_moves = int(max_moves)
+
+        # Observation config (1x1xC binary channels, optionally flattened)
+        # C = 2*num_agents + 1 (two action-bits per agent + 1 crash bit)
+        self.n_obs_types = 2 * self.n_agents + 1
+        self.flatten_observations = bool(flatten_observations)
+
+        # RNG (not strictly needed; kept for parity)
+        self.rng = np.random.RandomState(0 if seed is None else seed)
+
+        # Runtime state
+        self.agents: list[str] = []
+        self._round = 0
+        self._last_actions: dict[str, int | None] = {}  # Actions.{Swerve,Straight} or None
+        self._last_crash: bool = False
+
+        # rendering-relevant runtime state
+        self.render_mode = render_mode
+        self._renderer = None
+        # self._renderer: ChickenRenderer | None = None
+        # if self.render_mode is not None:
+        #     self._renderer = ChickenRenderer(self.render_mode)
+        self._cum_rewards: dict[str, float] = {}
+
+        # Spaces
+        self.observation_spaces = {a: self.observation_space(a) for a in self.possible_agents}
+        self.action_spaces = {a: self.action_space(a) for a in self.possible_agents}
+
+    # ─────────────────────────── PettingZoo API ───────────────────────────
+    @functools.lru_cache(maxsize=None)
+    def observation_space(self, agent):
+        C = self.n_obs_types
+        if self.flatten_observations:
+            return Box(low=0, high=1, shape=(C,), dtype=np.uint8)
+        return Box(low=0, high=1, shape=(1, 1, C), dtype=np.uint8)
+
+    @functools.lru_cache(maxsize=None)
+    def action_space(self, agent):
+        # 0 = Swerve, 1 = Straight
+        return Discrete(2)
+
+    def reset(self, seed: int | None = None, options: dict | None = None):
+        if seed is not None:
+            self.rng = np.random.RandomState(seed)
+
+        self.agents = self.possible_agents[:]
+        self._round = 0
+        self._last_actions = {a: None for a in self.agents}
+        self._last_crash = False
+        self._cum_rewards = {a: 0.0 for a in self.agents}
+
+        obs = {a: self._obs() for a in self.agents}
+        infos = {a: {"round": self._round, "last_actions": None, "crash": False} for a in self.agents}
+        return obs, infos
+
+    def step(self, actions: dict[str, int]):
+        if not actions:
+            self.agents = []
+            return {}, {}, {}, {}, {}
+
+        # Only two agents supported
+        a0, a1 = self.possible_agents
+        act0 = int(actions.get(a0, Actions.Swerve))
+        act1 = int(actions.get(a1, Actions.Swerve))
+
+        # Stage payoffs
+        self._last_crash = act0 == Actions.Straight and act1 == Actions.Straight
+        if act0 == Actions.Straight and act1 == Actions.Swerve:
+            r0, r1 = self.T, self.S
+            outcome = "Straight-Swerve"
+        elif act0 == Actions.Swerve and act1 == Actions.Straight:
+            r0, r1 = self.S, self.T
+            outcome = "Swerve-Straight"
+        elif act0 == Actions.Swerve and act1 == Actions.Swerve:
+            r0, r1 = self.R, self.R
+            outcome = "Swerve-Swerve"
+        else:  # both Straight
+            r0, r1 = self.P, self.P
+            outcome = "Straight-Straight"
+
+        rewards = {a0: float(r0), a1: float(r1)}
+
+        # Update last actions for observation
+        self._last_actions[a0] = act0
+        self._last_actions[a1] = act1
+        self._cum_rewards["player_0"] += r0
+        self._cum_rewards["player_1"] += r1
+
+        # Time & termination
+        self._round += 1
+        env_trunc = self._round >= self.max_moves
+
+        terminations = {a0: False, a1: False}
+        truncations = {a0: env_trunc, a1: env_trunc}
+        infos = {
+            a0: {"round": self._round, "last_actions": (act0, act1), "outcome": outcome, "crash": self._last_crash},
+            a1: {"round": self._round, "last_actions": (act1, act0), "outcome": outcome, "crash": self._last_crash},
+        }
+
+        obs = {a: self._obs() for a in self.agents}
+        if env_trunc:
+            for a in self.agents:
+                truncations[a] = True
+            self.agents = []
+
+        if self.render_mode in ("human", "rgb_array"):
+            self.render()
+
+        return obs, rewards, terminations, truncations, infos
+
+    def render(self):
+        if self.render_mode is None:
+            return
+        if not self._renderer:
+            raise ValueError("Renderer missing; create env with render_mode='human' or 'rgb_array'.")
+
+        pay = {"T": self.T, "R": self.R, "S": self.S, "P": self.P}
+        last = (self._last_actions.get("player_0"), self._last_actions.get("player_1"))
+
+        frame = self._renderer.render(
+            round_no=self._round,
+            last_actions=last,
+            last_crash=self._last_crash,
+            cum_rewards=self._cum_rewards,
+            payoffs=pay,
+        )
+        return frame
+
+    def close(self):
+        if self._renderer:
+            self._renderer.close()
+
+    # ───────────────────────────── Internals ─────────────────────────────
+    def _obs(self):
+        """
+        Binary channels, either (C,) or (1,1,C):
+          ch0 = p0 Swerve, ch1 = p0 Straight,
+          ch2 = p1 Swerve, ch3 = p1 Straight,
+          ch4 = crash flag
+        """
+        C = self.n_obs_types
+        v = np.zeros((C,), dtype=np.uint8)
+
+        def set_bits(pid: str, base: int):
+            a = self._last_actions.get(pid, None)
+            if a is None:
+                return
+            if a == Actions.Swerve:
+                v[base + 0] = 1
+            elif a == Actions.Straight:
+                v[base + 1] = 1
+
+        set_bits("player_0", 0)
+        set_bits("player_1", 2)
+        v[2 * self.n_agents] = 1 if self._last_crash else 0
+
+        if self.flatten_observations:
+            return v
+        return v.reshape(1, 1, -1)
+
+    # ────────────────────────────────────────────────────────────────────
+    #                          State helpers
+    # ────────────────────────────────────────────────────────────────────
+    @property
+    def state_space(self):
+        C = self.n_obs_types
+        if self.flatten_observations:
+            return Box(low=0, high=1, shape=(C,), dtype=np.uint8)
+        return Box(low=0, high=1, shape=(1, 1, C), dtype=np.uint8)
+
+    def state(self):
+        return self._obs()
+
+    def num_cells(self) -> int:
+        """Number of spatial cells in the layered observation grid.
+
+        ChickenMatrix is non-spatial: the entire game state is a single global cell.
+        This returns 1 regardless of whether observations are flattened or shaped (1, 1, C).
+        """
+        return 1
+
+    def channel_names(self) -> list[str]:
+        """
+        Human-friendly names for each observation channel index.
+
+        Channels (by construction in _obs):
+          ch0 = player_0 Swerve
+          ch1 = player_0 Straight
+          ch2 = player_1 Swerve
+          ch3 = player_1 Straight
+          ch4 = crash flag
+        """
+        names: list[str] = ["" for _ in range(self.n_obs_types)]
+
+        # Per-agent action bits: (Swerve, Straight)
+        for i in range(self.n_agents):
+            sw_idx = 2 * i
+            st_idx = 2 * i + 1
+            if sw_idx < self.n_obs_types:
+                names[sw_idx] = f"player_{i}_swerve"
+            if st_idx < self.n_obs_types:
+                names[st_idx] = f"player_{i}_straight"
+
+        # Crash flag
+        crash_idx = 2 * self.n_agents
+        if crash_idx < self.n_obs_types:
+            names[crash_idx] = "crash"
+
+        # Fallback for any unnamed channels (future-proofing)
+        for i, name in enumerate(names):
+            if not name:
+                names[i] = f"channel_{i}"
+
+        return names
+
+    def action_names(self, action: int) -> str:
+        """
+        Human-friendly name for an action integer ID.
+        """
+        try:
+            name = Actions(int(action)).name
+        except ValueError:
+            return f"action_{action}"
+        return "".join(
+            f"_{ch.lower()}" if ch.isupper() and i > 0 else ch.lower()
+            for i, ch in enumerate(name)
+        )
+
+    # ────────────────────────────────────────────────────────────────────
+    #               Lightweight state serialization
+    # ────────────────────────────────────────────────────────────────────
+    def get_state(self):
+        """
+        Fully restorable snapshot (no deep clone).
+
+        Tuple layout:
+          (
+            agents: tuple[str, ...],
+            round_no: int,
+            last_actions: tuple[int|None, int|None],  # (player_0, player_1)
+            last_crash: bool,
+            cum_rewards: tuple[float, float],         # (player_0, player_1)
+            rng_state: object                         # np.random.RandomState.get_state()
+          )
+        """
+        agents = tuple(self.agents) if getattr(self, "agents", None) is not None else tuple()
+
+        p0, p1 = self.possible_agents
+        last_actions = (self._last_actions.get(p0, None), self._last_actions.get(p1, None))
+        cum_rewards = (float(self._cum_rewards.get(p0, 0.0)), float(self._cum_rewards.get(p1, 0.0)))
+
+        rng_state = self.rng.get_state()
+        return (
+            agents,
+            int(self._round),
+            last_actions,
+            bool(self._last_crash),
+            cum_rewards,
+            rng_state,
+        )
+
+    def set_state(self, state):
+        """
+        Restore a snapshot produced by get_state().
+        """
+        (
+            agents,
+            round_no,
+            last_actions,
+            last_crash,
+            cum_rewards,
+            rng_state,
+        ) = state
+
+        self.agents = list(agents)
+        self._round = int(round_no)
+
+        p0, p1 = self.possible_agents
+
+        if len(last_actions) != 2:
+            raise ValueError(f"ChickenMatrix.set_state: last_actions must be len 2, got {len(last_actions)}")
+        if len(cum_rewards) != 2:
+            raise ValueError(f"ChickenMatrix.set_state: cum_rewards must be len 2, got {len(cum_rewards)}")
+
+        self._last_actions = {
+            p0: (None if last_actions[0] is None else int(last_actions[0])),
+            p1: (None if last_actions[1] is None else int(last_actions[1])),
+        }
+        self._last_crash = bool(last_crash)
+
+        # Keep keys consistent with step() update style ("player_0"/"player_1")
+        self._cum_rewards = {
+            p0: float(cum_rewards[0]),
+            p1: float(cum_rewards[1]),
+        }
+
+        if rng_state is not None:
+            self.rng.set_state(rng_state)
+
+    def get_rng_state(self):
+        return self.rng.get_state()
+
+    def set_rng_state(self, rng_state):
+        self.rng.set_state(rng_state)
+
+    def reseed(self, seed: int):
+        self.rng = np.random.RandomState(int(seed))

--- a/masa/envs/multiagent/matrix/congestion.py
+++ b/masa/envs/multiagent/matrix/congestion.py
@@ -1,0 +1,440 @@
+from __future__ import annotations
+
+import functools
+from typing import Dict
+from enum import IntEnum
+
+import numpy as np
+from gymnasium.spaces import Box, Discrete
+from pettingzoo import ParallelEnv
+
+
+class Actions(IntEnum):
+    RoadA = 0
+    RoadB = 1
+
+class CongestionMatrix(ParallelEnv):
+    """
+    6-agent congestion routing with 2 roads (A/B). Each agent picks a road.
+    Per-road cost is linear in the number of users on that road:
+        cost_A = base_A + slope_A * nA
+        cost_B = base_B + slope_B * nB
+    Agent reward = - cost_(chosen road)  (more congestion => lower reward)
+    Optional jam penalty adds extra negative reward to agents on an overfull road.
+
+    Defaults: 6 agents, base_A=1, base_B=1, slope_A=1, slope_B=1,
+              jam_threshold=5, jam_penalty=5.
+
+    Observations (global, binary channels), shape is (C,) if flattened or (1,1,C):
+      - For each agent i in {0..N-1}:
+            ch 2*i + 0 = 1 if last action was RoadA, else 0
+            ch 2*i + 1 = 1 if last action was RoadB, else 0
+      - One-hot for last round load of RoadA over (N+1) buckets [0..N]
+      - One-hot for last round load of RoadB over (N+1) buckets [0..N]
+      - Jam flag (1 if max(nA, nB) >= jam_threshold else 0)
+
+      On the first round (after reset), all action bits are 0 and load one-hots
+      reflect (0 users on A, 0 users on B); jam=0.
+    """
+
+    metadata = {"name": "congestion_matrix_v0", "render_modes": ["human", "rgb_array"]}
+
+    def __init__(
+        self,
+        *,
+        num_agents: int = 6,
+        max_moves: int = 200,
+        base_A: float = 1.0,
+        base_B: float = 1.0,
+        slope_A: float = 1.0,
+        slope_B: float = 1.0,
+        jam_threshold: int = 5,
+        jam_penalty: float = 5.0,
+        flatten_observations: bool = True,
+        render_mode=None,
+        seed: int | None = None,
+    ):
+        assert num_agents >= 2, "CongestionMatrix needs at least 2 agents."
+        self.n_agents = int(num_agents)
+        self.possible_agents = [f"player_{i}" for i in range(self.n_agents)]
+
+        # Cost params
+        self.base_A = float(base_A)
+        self.base_B = float(base_B)
+        self.slope_A = float(slope_A)
+        self.slope_B = float(slope_B)
+
+        # Jam params
+        self.jam_threshold = int(jam_threshold)
+        self.jam_penalty = float(jam_penalty)
+
+        # Horizon
+        self.max_moves = int(max_moves)
+
+        # Observation config
+        #  - 2 bits per agent for last actions
+        #  - (N+1) one-hot for loadA + (N+1) one-hot for loadB
+        #  - 1 jam flag
+        self.flatten_observations = bool(flatten_observations)
+        self.n_obs_types = 2 * self.n_agents + 2 * (self.n_agents + 1) + 1
+
+        # RNG
+        self.rng = np.random.RandomState(0 if seed is None else seed)
+
+        # Runtime
+        self.agents: list[str] = []
+        self._round = 0
+        self._last_actions: dict[str, int | None] = {}
+        self._loadA: int = 0
+        self._loadB: int = 0
+        self._jam: bool = False
+        self._cum_rewards: dict[str, float] = {}
+
+        # Rendering
+        self.render_mode = render_mode
+        self._renderer = None
+        # self._renderer: CongestionRenderer | None = None
+        # if self.render_mode is not None:
+        #     self._renderer = CongestionRenderer(self.render_mode)
+
+        # Spaces
+        self.observation_spaces = {a: self.observation_space(a) for a in self.possible_agents}
+        self.action_spaces = {a: self.action_space(a) for a in self.possible_agents}
+
+    # ─────────────────────────── PettingZoo API ───────────────────────────
+    @functools.lru_cache(maxsize=None)
+    def observation_space(self, agent):
+        C = self.n_obs_types
+        if self.flatten_observations:
+            return Box(low=0, high=1, shape=(C,), dtype=np.uint8)
+        return Box(low=0, high=1, shape=(1, 1, C), dtype=np.uint8)
+
+    @functools.lru_cache(maxsize=None)
+    def action_space(self, agent):
+        return Discrete(2)  # 0=A, 1=B
+
+    def reset(self, seed: int | None = None, options: dict | None = None):
+        if seed is not None:
+            self.rng = np.random.RandomState(seed)
+
+        self.agents = self.possible_agents[:]
+        self._round = 0
+        self._last_actions = {a: None for a in self.agents}
+        self._loadA = 0
+        self._loadB = 0
+        self._jam = False
+        self._cum_rewards = {a: 0.0 for a in self.agents}
+
+        obs = {a: self._obs() for a in self.agents}
+        infos = {
+            a: {"round": self._round, "last_actions": None, "loads": (self._loadA, self._loadB), "jam": self._jam}
+            for a in self.agents
+        }
+        return obs, infos
+
+    def step(self, actions: dict[str, int]):
+        # Check that the episode is not already over
+        if not self.agents:
+            return {}, {}, {}, {}, {}
+
+        # Require one action per active agent
+        expected = set(self.agents)
+        received = set(actions.keys())
+        if expected != received:
+            missing = expected - received
+            extra = received - expected
+            msg_parts = []
+            if missing:
+                msg_parts.append(f"missing actions for agents: {sorted(missing)}")
+            if extra:
+                msg_parts.append(f"got actions for non-existent agents: {sorted(extra)}")
+            raise ValueError("Invalid action dict: " + "; ".join(msg_parts))
+
+        chosen: dict[str, int] = {}
+        for a in self.agents:
+            chosen[a] = int(actions[a])
+
+        nA = sum(1 for a in self.possible_agents if chosen[a] == Actions.RoadA)
+        nB = self.n_agents - nA
+
+        # Costs & rewards
+        costA = self.base_A + self.slope_A * float(nA)
+        costB = self.base_B + self.slope_B * float(nB)
+
+        jamA = nA >= self.jam_threshold
+        jamB = nB >= self.jam_threshold
+        jam_now = jamA or jamB
+
+        rewards: Dict[str, float] = {}
+        for a in self.possible_agents:
+            if chosen[a] == Actions.RoadA:
+                r = -costA
+                if jamA:
+                    r -= self.jam_penalty
+            else:
+                r = -costB
+                if jamB:
+                    r -= self.jam_penalty
+            rewards[a] = float(r)
+
+        # Update runtime state
+        for a in self.possible_agents:
+            self._last_actions[a] = chosen[a]
+            self._cum_rewards[a] += rewards[a]
+        self._loadA, self._loadB = nA, nB
+        self._jam = bool(jam_now)
+
+        # Time & termination
+        self._round += 1
+        env_trunc = self._round >= self.max_moves
+
+        terminations = {a: False for a in self.possible_agents}
+        truncations = {a: env_trunc for a in self.possible_agents}
+        infos = {
+            a: {
+                "round": self._round,
+                "last_actions": tuple(chosen[x] for x in self.possible_agents),
+                "loads": (nA, nB),
+                "jam": jam_now,
+                "costs": (costA, costB),
+            }
+            for a in self.possible_agents
+        }
+
+        obs = {a: self._obs() for a in self.agents}
+        if env_trunc:
+            self.agents = []
+
+        if self.render_mode in ("human", "rgb_array"):
+            self.render()
+
+        return obs, rewards, terminations, truncations, infos
+
+    def render(self):
+        if self.render_mode is None:
+            return
+        if not self._renderer:
+            raise ValueError("Renderer missing; create env with render_mode='human' or 'rgb_array'.")
+
+        params = {
+            "base_A": self.base_A,
+            "base_B": self.base_B,
+            "slope_A": self.slope_A,
+            "slope_B": self.slope_B,
+            "nA": self._loadA,
+            "nB": self._loadB,
+            "jam": self._jam,
+        }
+        last_list = [self._last_actions.get(a) for a in self.possible_agents]
+
+        frame = self._renderer.render(
+            round_no=self._round,
+            last_actions=last_list,
+            cum_rewards=self._cum_rewards,
+            params=params,
+        )
+        return frame
+
+    def close(self):
+        if self._renderer:
+            self._renderer.close()
+
+    # ───────────────────────────── Internals ─────────────────────────────
+    def _obs(self):
+        """
+        Layout (C = 2N + (N+1) + (N+1) + 1):
+          [ per-agent action bits | loadA one-hot | loadB one-hot | jam ]
+        """
+        N = self.n_agents
+        C = self.n_obs_types
+        v = np.zeros((C,), dtype=np.uint8)
+
+        # per-agent bits
+        for i, pid in enumerate(self.possible_agents):
+            a = self._last_actions.get(pid, None)
+            base = 2 * i
+            if a is None:
+                continue
+            if a == Actions.RoadA:
+                v[base + 0] = 1
+            elif a == Actions.RoadB:
+                v[base + 1] = 1
+
+        # load one-hots
+        offset = 2 * N
+        v[offset + int(self._loadA)] = 1
+        offset += N + 1
+        v[offset + int(self._loadB)] = 1
+        offset += N + 1
+
+        # jam flag
+        v[offset] = 1 if self._jam else 0
+
+        if self.flatten_observations:
+            return v
+        return v.reshape(1, 1, -1)
+
+    # ────────────────────────────────────────────────────────────────────
+    #                          State helpers
+    # ────────────────────────────────────────────────────────────────────
+    @property
+    def state_space(self):
+        C = self.n_obs_types
+        if self.flatten_observations:
+            return Box(low=0, high=1, shape=(C,), dtype=np.uint8)
+        return Box(low=0, high=1, shape=(1, 1, C), dtype=np.uint8)
+
+    def state(self):
+        return self._obs()
+
+    def num_cells(self) -> int:
+        """Non-spatial global state → single cell."""
+        return 1
+
+    def channel_names(self) -> list[str]:
+        """
+        Human-friendly names for each observation channel index.
+
+        Layout (see _obs):
+          0..2*N-1              : per-agent action bits (A/B) in blocks of 2
+          2*N .. 2*N+N          : loadA one-hot over [0..N]
+          2*N+N+1 .. 2*N+2*N+1  : loadB one-hot over [0..N]
+          last                  : jam flag
+        """
+        names: list[str] = ["" for _ in range(self.n_obs_types)]
+
+        N = self.n_agents
+
+        # Per-agent action bits
+        for i in range(N):
+            a_idx = 2 * i
+            b_idx = 2 * i + 1
+            if a_idx < self.n_obs_types:
+                names[a_idx] = f"player_{i}_roadA"
+            if b_idx < self.n_obs_types:
+                names[b_idx] = f"player_{i}_roadB"
+
+        # loadA one-hot bins
+        offset = 2 * N
+        for k in range(N + 1):
+            idx = offset + k
+            if idx >= self.n_obs_types:
+                break
+            names[idx] = f"loadA_{k}"
+
+        # loadB one-hot bins
+        offset += N + 1
+        for k in range(N + 1):
+            idx = offset + k
+            if idx >= self.n_obs_types:
+                break
+            names[idx] = f"loadB_{k}"
+
+        # jam flag
+        offset += N + 1
+        if offset < self.n_obs_types:
+            names[offset] = "jam"
+
+        # Fallback for any unnamed channels
+        for i, name in enumerate(names):
+            if not name:
+                names[i] = f"channel_{i}"
+
+        return names
+
+    def action_names(self, action: int) -> str:
+        """
+        Human-friendly name for an action integer ID.
+        """
+        try:
+            name = Actions(int(action)).name
+        except ValueError:
+            return f"action_{action}"
+        return "".join(
+            f"_{ch.lower()}" if ch.isupper() and i > 0 else ch.lower()
+            for i, ch in enumerate(name)
+        )
+
+    # ────────────────────────────────────────────────────────────────────
+    #               Lightweight state serialization
+    # ────────────────────────────────────────────────────────────────────
+    def get_state(self):
+        """
+        Returns a lightweight, fully-restorable snapshot.
+
+        Tuple layout:
+          (
+            agents: tuple[str, ...],
+            round_no: int,
+            last_actions: tuple[int|None, ...]   # len = n_agents, in possible_agents order
+            loadA: int,
+            loadB: int,
+            jam: bool,
+            cum_rewards: tuple[float, ...]       # len = n_agents, in possible_agents order
+            rng_state: object                    # np.random.RandomState.get_state()
+          )
+        """
+        agents = tuple(self.agents) if getattr(self, "agents", None) is not None else tuple()
+        last_actions = tuple(self._last_actions.get(a, None) for a in self.possible_agents)
+        cum_rewards = tuple(float(self._cum_rewards.get(a, 0.0)) for a in self.possible_agents)
+        rng_state = self.rng.get_state()  # fully reproducible
+        return (
+            agents,
+            int(self._round),
+            last_actions,
+            int(self._loadA),
+            int(self._loadB),
+            bool(self._jam),
+            cum_rewards,
+            rng_state,
+        )
+
+    def set_state(self, state):
+        """
+        Restore a snapshot produced by get_state().
+        """
+        (
+            agents,
+            round_no,
+            last_actions,
+            loadA,
+            loadB,
+            jam,
+            cum_rewards,
+            rng_state,
+        ) = state
+
+        self.agents = list(agents)
+        self._round = int(round_no)
+
+        # restore last actions / cum rewards in possible_agents order
+        if len(last_actions) != self.n_agents:
+            raise ValueError(
+                f"CongestionMatrix.set_state: last_actions len {len(last_actions)} != n_agents {self.n_agents}"
+            )
+        if len(cum_rewards) != self.n_agents:
+            raise ValueError(
+                f"CongestionMatrix.set_state: cum_rewards len {len(cum_rewards)} != n_agents {self.n_agents}"
+            )
+
+        self._last_actions = {
+            a: (None if last_actions[i] is None else int(last_actions[i])) for i, a in enumerate(self.possible_agents)
+        }
+        self._cum_rewards = {a: float(cum_rewards[i]) for i, a in enumerate(self.possible_agents)}
+
+        self._loadA = int(loadA)
+        self._loadB = int(loadB)
+        self._jam = bool(jam)
+
+        # restore RNG
+        if rng_state is not None:
+            self.rng.set_state(rng_state)
+
+    def get_rng_state(self):
+        return self.rng.get_state()
+
+    def set_rng_state(self, rng_state):
+        self.rng.set_state(rng_state)
+
+    def reseed(self, seed: int):
+        self.rng = np.random.RandomState(int(seed))

--- a/masa/envs/multiagent/matrix/dpgg.py
+++ b/masa/envs/multiagent/matrix/dpgg.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+import functools
+from enum import IntEnum
+
+import numpy as np
+from gymnasium.spaces import Box, Discrete
+from pettingzoo import ParallelEnv
+
+class Actions(IntEnum):
+    Contribute = 0
+    Withhold   = 1
+
+class DPGGMatrix(ParallelEnv):
+    """
+    Dynamic Public Goods Game (Parallel PettingZoo), 2 players.
+
+    (Markov + binary obs):
+      - Pot is discretized to a fixed step size `pot_step`.
+      - Internal pot state is an integer index: self._pot_idx
+      - Observations include the exact pot index encoded as binary bits (uint8 0/1)
+
+    Observation channels (binary):
+      For each agent i in {0,1}:
+        ch 2*i + 0 = 1 if agent_i last action was Contribute
+        ch 2*i + 1 = 1 if agent_i last action was Withhold
+      Plus:
+        pot_bits bits encoding pot_idx (LSB-first), where
+          pot_idx in [0, pot_levels-1]
+          pot_value = pot_idx * pot_step
+          pot_levels = floor(pot_cap / pot_step) + 1
+    """
+
+    metadata = {"name": "dpgg_matrix_v0", "render_modes": ["human", "rgb_array"]}
+
+    def __init__(
+        self,
+        *,
+        num_agents: int = 2,
+        max_moves: int = 200,
+        # DPGG parameters
+        contribution_cost: float = 10.0,
+        alpha: float = 1.5,
+        payout_rate: float = 0.3,
+        decay: float = 0.0,
+        initial_pot: float = 0.0,
+        pot_cap: float = 500.0,
+        # NEW: discretization granularity (keep it > 0)
+        pot_step: float = 1.0,
+        flatten_observations: bool = True,
+        render_mode=None,
+        seed: int | None = None,
+    ):
+        assert num_agents == 2, "DPGGMatrix currently supports exactly 2 agents."
+        self.n_agents = int(num_agents)
+        self.possible_agents = [f"player_{i}" for i in range(self.n_agents)]
+
+        # Parameters
+        self.c = float(contribution_cost)
+        self.alpha = float(alpha)
+        self.payout_rate = float(np.clip(payout_rate, 0.0, 1.0))
+        self.decay = float(np.clip(decay, 0.0, 1.0))
+        self.initial_pot = float(max(0.0, initial_pot))
+        self.pot_cap = float(max(0.0, pot_cap))
+
+        # Pot discretization
+        self.pot_step = float(pot_step)
+        if not np.isfinite(self.pot_step) or self.pot_step <= 0.0:
+            raise ValueError(f"pot_step must be > 0, got {pot_step}")
+
+        # Number of discrete pot levels: 0, pot_step, 2*pot_step, ..., <= pot_cap
+        self.pot_levels = int(np.floor(self.pot_cap / self.pot_step)) + 1
+        self.pot_levels = max(2, self.pot_levels)
+
+        # Bits needed to represent pot_idx
+        self.pot_bits = int(np.ceil(np.log2(self.pot_levels)))
+        self.pot_bits = max(1, self.pot_bits)
+
+        # Repetition horizon
+        self.max_moves = int(max_moves)
+
+        # Observation config (binary channels, optionally flattened)
+        # C = 2*num_agents + pot_bits
+        self.n_obs_types = 2 * self.n_agents + self.pot_bits
+        self.flatten_observations = bool(flatten_observations)
+
+        # RNG (parity with your other envs)
+        self.rng = np.random.RandomState(0 if seed is None else seed)
+
+        # Runtime state
+        self.agents: list[str] = []
+        self._round = 0
+        self._last_actions: dict[str, int | None] = {}
+        self._pot_idx: int = 0  # discrete pot state
+        self._cum_rewards: dict[str, float] = {}
+
+        # rendering
+        self.render_mode = render_mode
+        self._renderer = None
+        # self._renderer: DPGGRenderer | None = None
+        # if self.render_mode is not None:
+        #     self._renderer = DPGGRenderer(self.render_mode)
+
+        # Spaces
+        self.observation_spaces = {a: self.observation_space(a) for a in self.possible_agents}
+        self.action_spaces = {a: self.action_space(a) for a in self.possible_agents}
+
+    # ─────────────────────────── PettingZoo API ───────────────────────────
+    @functools.lru_cache(maxsize=None)
+    def observation_space(self, agent):
+        C = self.n_obs_types
+        if self.flatten_observations:
+            return Box(low=0, high=1, shape=(C,), dtype=np.uint8)
+        return Box(low=0, high=1, shape=(1, 1, C), dtype=np.uint8)
+
+    @functools.lru_cache(maxsize=None)
+    def action_space(self, agent):
+        return Discrete(2)
+
+    def reset(self, seed: int | None = None, options: dict | None = None):
+        if seed is not None:
+            self.rng = np.random.RandomState(seed)
+
+        self.agents = self.possible_agents[:]
+        self._round = 0
+        self._last_actions = {a: None for a in self.agents}
+        self._cum_rewards = {a: 0.0 for a in self.agents}
+
+        # Quantize initial pot onto discrete grid
+        self._pot_idx = self._pot_value_to_idx(self.initial_pot)
+
+        obs = {a: self._obs() for a in self.agents}
+        infos = {
+            a: {
+                "round": self._round,
+                "last_actions": None,
+                "pot": self._pot_value(),
+                "pot_idx": self._pot_idx,
+                "payout": 0.0,
+                "contributors": 0,
+            }
+            for a in self.agents
+        }
+        return obs, infos
+
+    def step(self, actions: dict[str, int]):
+        if not actions:
+            self.agents = []
+            return {}, {}, {}, {}, {}
+
+        a0, a1 = self.possible_agents
+        act0 = int(actions.get(a0, Actions.Contribute))
+        act1 = int(actions.get(a1, Actions.Contribute))
+
+        # Current discrete pot value
+        pot_before = self._pot_value()
+        payout_total = self.payout_rate * pot_before
+        share = payout_total / self.n_agents
+
+        cost0 = self.c if act0 == Actions.Contribute else 0.0
+        cost1 = self.c if act1 == Actions.Contribute else 0.0
+
+        r0 = share - cost0
+        r1 = share - cost1
+        rewards = {a0: float(r0), a1: float(r1)}
+
+        # Update last actions & cumulative rewards
+        self._last_actions[a0] = act0
+        self._last_actions[a1] = act1
+        self._cum_rewards[a0] += r0
+        self._cum_rewards[a1] += r1
+
+        # Pot update (float math), then quantize back to discrete grid
+        pot_after = pot_before - payout_total
+        pot_after = max(0.0, pot_after) * (1.0 - self.decay)
+
+        contributors = (1 if act0 == Actions.Contribute else 0) + (1 if act1 == Actions.Contribute else 0)
+        pot_after += self.alpha * self.c * contributors
+        pot_after = float(np.clip(pot_after, 0.0, self.pot_cap))
+
+        self._pot_idx = self._pot_value_to_idx(pot_after)
+
+        # Time & termination
+        self._round += 1
+        env_trunc = self._round >= self.max_moves
+
+        terminations = {a0: False, a1: False}
+        truncations = {a0: env_trunc, a1: env_trunc}
+
+        infos = {
+            a0: {
+                "round": self._round,
+                "last_actions": (act0, act1),
+                "pot_before": pot_before,
+                "pot": self._pot_value(),
+                "pot_idx": self._pot_idx,
+                "payout": payout_total,
+                "contributors": contributors,
+            },
+            a1: {
+                "round": self._round,
+                "last_actions": (act1, act0),
+                "pot_before": pot_before,
+                "pot": self._pot_value(),
+                "pot_idx": self._pot_idx,
+                "payout": payout_total,
+                "contributors": contributors,
+            },
+        }
+
+        obs = {a: self._obs() for a in self.agents}
+        if env_trunc:
+            for a in self.agents:
+                truncations[a] = True
+            self.agents = []
+
+        if self.render_mode in ("human", "rgb_array"):
+            self.render()
+
+        return obs, rewards, terminations, truncations, infos
+
+    def render(self):
+        if self.render_mode is None:
+            return
+        if not self._renderer:
+            raise ValueError("Renderer missing; create env with render_mode='human' or 'rgb_array'.")
+
+        last = (self._last_actions.get("player_0"), self._last_actions.get("player_1"))
+        params = {
+            "c": self.c,
+            "alpha": self.alpha,
+            "payout_rate": self.payout_rate,
+            "decay": self.decay,
+            "pot": self._pot_value(),
+        }
+
+        frame = self._renderer.render(
+            round_no=self._round,
+            last_actions=last,
+            cum_rewards=self._cum_rewards,
+            params=params,
+        )
+        return frame
+
+    def close(self):
+        if self._renderer:
+            self._renderer.close()
+
+    # ───────────────────────────── Internals ─────────────────────────────
+    def _pot_value(self) -> float:
+        """Current pot value (float) implied by discrete pot index."""
+        return float(self._pot_idx) * self.pot_step
+
+    def _pot_value_to_idx(self, pot_value: float) -> int:
+        """
+        Quantize a pot value onto the discrete grid.
+
+        We use deterministic "round half up" to avoid Python's bankers-rounding:
+          idx = floor(x + 0.5)
+        """
+        x = float(np.clip(pot_value, 0.0, self.pot_cap)) / self.pot_step
+        idx = int(np.floor(x + 0.5))
+        if idx < 0:
+            idx = 0
+        if idx > self.pot_levels - 1:
+            idx = self.pot_levels - 1
+        return idx
+
+    def _obs(self):
+        """
+        Binary channels, either (C,) or (1,1,C):
+          ch0 = p0 Contribute, ch1 = p0 Withhold,
+          ch2 = p1 Contribute, ch3 = p1 Withhold,
+          ch(4..4+pot_bits-1) = pot_idx bits (LSB-first)
+        """
+        C = self.n_obs_types
+        v = np.zeros((C,), dtype=np.uint8)
+
+        def set_bits(pid: str, base: int):
+            a = self._last_actions.get(pid, None)
+            if a is None:
+                return
+            if a == Actions.Contribute:
+                v[base + 0] = 1
+            elif a == Actions.Withhold:
+                v[base + 1] = 1
+
+        set_bits("player_0", 0)
+        set_bits("player_1", 2)
+
+        # pot bits
+        start = 2 * self.n_agents
+        idx = int(self._pot_idx)
+        for b in range(self.pot_bits):
+            v[start + b] = (idx >> b) & 1
+
+        if self.flatten_observations:
+            return v
+        return v.reshape(1, 1, -1)
+
+    # ────────────────────────────────────────────────────────────────────
+    #                          State helpers
+    # ────────────────────────────────────────────────────────────────────
+    @property
+    def state_space(self):
+        C = self.n_obs_types
+        if self.flatten_observations:
+            return Box(low=0, high=1, shape=(C,), dtype=np.uint8)
+        return Box(low=0, high=1, shape=(1, 1, C), dtype=np.uint8)
+
+    def state(self):
+        return self._obs()
+
+    def num_cells(self) -> int:
+        return 1
+
+    def channel_names(self) -> list[str]:
+        names: list[str] = ["" for _ in range(self.n_obs_types)]
+
+        # Per-agent action bits
+        for i in range(self.n_agents):
+            c_idx = 2 * i
+            w_idx = 2 * i + 1
+            names[c_idx] = f"player_{i}_contribute"
+            names[w_idx] = f"player_{i}_withhold"
+
+        # Pot bits
+        start = 2 * self.n_agents
+        for b in range(self.pot_bits):
+            names[start + b] = f"pot_bit_{b}"  # LSB-first
+
+        for i, name in enumerate(names):
+            if not name:
+                names[i] = f"channel_{i}"
+        return names
+
+    def action_names(self, action: int) -> str:
+        """
+        Human-friendly name for an action integer ID.
+        """
+        try:
+            name = Actions(int(action)).name
+        except ValueError:
+            return f"action_{action}"
+        return "".join(
+            f"_{ch.lower()}" if ch.isupper() and i > 0 else ch.lower()
+            for i, ch in enumerate(name)
+        )
+
+    # ────────────────────────────────────────────────────────────────────
+    #               Lightweight state serialization
+    # ────────────────────────────────────────────────────────────────────
+    def get_state(self):
+        """
+        Tuple layout:
+          (
+            agents: tuple[str, ...],
+            round_no: int,
+            last_actions: tuple[int|None, int|None],  # (p0, p1)
+            pot_idx: int,
+            cum_rewards: tuple[float, float],         # (p0, p1)
+            rng_state: object
+          )
+        """
+        agents = tuple(self.agents) if getattr(self, "agents", None) is not None else tuple()
+        a0, a1 = self.possible_agents
+        last = (self._last_actions.get(a0, None), self._last_actions.get(a1, None))
+        cum = (float(self._cum_rewards.get(a0, 0.0)), float(self._cum_rewards.get(a1, 0.0)))
+        rng_state = self.rng.get_state()
+        return (agents, int(self._round), last, int(self._pot_idx), cum, rng_state)
+
+    def set_state(self, state):
+        (agents, round_no, last, pot_idx, cum, rng_state) = state
+
+        self.agents = list(agents)
+        self._round = int(round_no)
+
+        a0, a1 = self.possible_agents
+        if len(last) != 2:
+            raise ValueError(f"DPGGMatrix.set_state: last_actions must be len 2, got {len(last)}")
+        if len(cum) != 2:
+            raise ValueError(f"DPGGMatrix.set_state: cum_rewards must be len 2, got {len(cum)}")
+
+        self._last_actions = {
+            a0: (None if last[0] is None else int(last[0])),
+            a1: (None if last[1] is None else int(last[1])),
+        }
+
+        self._pot_idx = int(np.clip(int(pot_idx), 0, self.pot_levels - 1))
+        self._cum_rewards = {a0: float(cum[0]), a1: float(cum[1])}
+
+        if rng_state is not None:
+            self.rng.set_state(rng_state)
+
+    def get_rng_state(self):
+        return self.rng.get_state()
+
+    def set_rng_state(self, rng_state):
+        self.rng.set_state(rng_state)
+
+    def reseed(self, seed: int):
+        self.rng = np.random.RandomState(int(seed))

--- a/masa/envs/multiagent/matrix/inspection.py
+++ b/masa/envs/multiagent/matrix/inspection.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import functools
+
+import numpy as np
+from enum import IntEnum
+from gymnasium.spaces import Box, Discrete
+from pettingzoo import ParallelEnv
+
+class InspectorActions(IntEnum):
+    NotInspect = 0
+    Inspect    = 1
+
+class InspecteeActions(IntEnum):
+    Comply  = 0
+    Violate = 1
+
+class InspectionMatrix(ParallelEnv):
+    """
+    Repeated 2-player Inspection game (Parallel PettingZoo)
+
+    Players:
+      - Row (player_0): Inspector — actions {NotInspect=0, Inspect=1}
+      - Col (player_1): Inspectee — actions {Comply=0, Violate=1}
+
+    Stage payoffs (Inspector, Inspectee):
+      (NotInspect, Comply)  -> (0, 0)
+      (NotInspect, Violate) -> (-h, b)        # undetected violation
+      (Inspect, Comply)     -> (-c, 0)
+      (Inspect, Violate)    -> (v - c, -f)
+
+    Defaults: b=5, f=10, c=2, h=4, v=3  (all floats)
+
+    Observations (global, binary channels), shape is either (C,) if flattened or (1,1,C):
+      For each agent i in {0,1}:
+        - ch 2*i + 0 = 1 if agent_i's last action was action 0, else 0
+        - ch 2*i + 1 = 1 if agent_i's last action was action 1, else 0
+      Plus:
+        - ch 2*num_agents = 1 if last outcome was an undetected violation ((NotInspect, Violate)), else 0
+
+      On the first round (after reset), all channels are 0.
+    """
+
+    metadata = {"name": "inspection_matrix_v0", "render_modes": ["human", "rgb_array"]}
+
+    def __init__(
+        self,
+        *,
+        num_agents: int = 2,
+        max_moves: int = 200,
+        b: float = 5.0,
+        f: float = 10.0,
+        c: float = 2.0,
+        h: float = 4.0,
+        v: float = 3.0,
+        flatten_observations: bool = True,
+        render_mode=None,
+        seed: int | None = None,
+    ):
+        assert num_agents == 2, "InspectionMatrix currently supports exactly 2 agents."
+        self.n_agents = int(num_agents)
+        self.possible_agents = [f"player_{i}" for i in range(self.n_agents)]
+
+        # Payoff parameters
+        self.b, self.f, self.c, self.h, self.v = float(b), float(f), float(c), float(h), float(v)
+
+        # Repetition horizon
+        self.max_moves = int(max_moves)
+
+        # Observation config (1x1xC binary channels, optionally flattened)
+        # C = 2*num_agents + 1 (two action-bits per agent + 1 undetected-violation bit)
+        self.n_obs_types = 2 * self.n_agents + 1
+        self.flatten_observations = bool(flatten_observations)
+
+        # RNG (parity with Chicken)
+        self.rng = np.random.RandomState(0 if seed is None else seed)
+
+        # Runtime state
+        self.agents: list[str] = []
+        self._round = 0
+        self._last_actions: dict[str, int | None] = {}  # {player: 0/1 or None}
+        self._last_undetected: bool = False
+
+        # rendering-relevant runtime state
+        self.render_mode = render_mode
+        self._renderer = None
+        # self._renderer: InspectionRenderer | None = None
+        # if self.render_mode is not None:
+        #     self._renderer = InspectionRenderer(self.render_mode)
+        # self._cum_rewards: dict[str, float] = {}
+
+        # Spaces
+        self.observation_spaces = {a: self.observation_space(a) for a in self.possible_agents}
+        self.action_spaces = {a: self.action_space(a) for a in self.possible_agents}
+
+    # ─────────────────────────── PettingZoo API ───────────────────────────
+    @functools.lru_cache(maxsize=None)
+    def observation_space(self, agent):
+        C = self.n_obs_types
+        if self.flatten_observations:
+            return Box(low=0, high=1, shape=(C,), dtype=np.uint8)
+        return Box(low=0, high=1, shape=(1, 1, C), dtype=np.uint8)
+
+    @functools.lru_cache(maxsize=None)
+    def action_space(self, agent):
+        # 0/1 for both players
+        return Discrete(2)
+
+    def reset(self, seed: int | None = None, options: dict | None = None):
+        if seed is not None:
+            self.rng = np.random.RandomState(seed)
+
+        self.agents = self.possible_agents[:]
+        self._round = 0
+        self._last_actions = {a: None for a in self.agents}
+        self._last_undetected = False
+        self._cum_rewards = {a: 0.0 for a in self.agents}
+
+        obs = {a: self._obs() for a in self.agents}
+        infos = {a: {"round": self._round, "last_actions": None, "undetected": False} for a in self.agents}
+        return obs, infos
+
+    def step(self, actions: dict[str, int]):
+        if not actions:
+            self.agents = []
+            return {}, {}, {}, {}, {}
+
+        # Only two agents supported
+        p0, p1 = self.possible_agents
+        # Defaults mirror Chicken's style (choose action 0 if missing)
+        act0 = int(actions.get(p0, InspectorActions.NotInspect))
+        act1 = int(actions.get(p1, InspecteeActions.Comply))
+
+        # Stage payoffs & undetected flag
+        if act0 == InspectorActions.NotInspect and act1 == InspecteeActions.Comply:  # (N, C)
+            r0, r1 = 0.0, 0.0
+            undetected = False
+            outcome = "NotInspect-Comply"
+        elif act0 == InspectorActions.NotInspect and act1 == InspecteeActions.Violate:  # (N, V)
+            r0, r1 = -self.h, self.b
+            undetected = True
+            outcome = "NotInspect-Violate"
+        elif act0 == InspectorActions.Inspect and act1 == InspecteeActions.Comply:  # (I, C)
+            r0, r1 = -self.c, 0.0
+            undetected = False
+            outcome = "Inspect-Comply"
+        else:  # (I, V)
+            r0, r1 = self.v - self.c, -self.f
+            undetected = False
+            outcome = "Inspect-Violate"
+
+        rewards = {p0: float(r0), p1: float(r1)}
+
+        # Update last actions / rewards
+        self._last_actions[p0] = int(act0)
+        self._last_actions[p1] = int(act1)
+        self._last_undetected = bool(undetected)
+        self._cum_rewards[p0] += r0
+        self._cum_rewards[p1] += r1
+
+        # Time & termination
+        self._round += 1
+        env_trunc = self._round >= self.max_moves
+
+        terminations = {p0: False, p1: False}
+        truncations = {p0: env_trunc, p1: env_trunc}
+        infos = {
+            p0: {
+                "round": self._round,
+                "last_actions": (act0, act1),
+                "outcome": outcome,
+                "undetected": self._last_undetected,
+            },
+            p1: {
+                "round": self._round,
+                "last_actions": (act1, act0),
+                "outcome": outcome,
+                "undetected": self._last_undetected,
+            },
+        }
+
+        obs = {a: self._obs() for a in self.agents}
+        if env_trunc:
+            for a in self.agents:
+                truncations[a] = True
+            self.agents = []
+
+        if self.render_mode in ("human", "rgb_array"):
+            self.render()
+
+        return obs, rewards, terminations, truncations, infos
+
+    def render(self):
+        if self.render_mode is None:
+            return
+        if not self._renderer:
+            raise ValueError("Renderer missing; create env with render_mode='human' or 'rgb_array'.")
+
+        last = (self._last_actions.get("player_0"), self._last_actions.get("player_1"))
+        params = {"b": self.b, "f": self.f, "c": self.c, "h": self.h, "v": self.v}
+
+        frame = self._renderer.render(
+            round_no=self._round,
+            last_actions=last,
+            last_undetected=self._last_undetected,
+            cum_rewards=self._cum_rewards,
+            params=params,
+        )
+        return frame
+
+    def close(self):
+        if self._renderer:
+            self._renderer.close()
+
+    # ───────────────────────────── Internals ─────────────────────────────
+    def _obs(self):
+        """
+        Binary channels, either (C,) or (1,1,C):
+          ch0 = p0 action==0 (NotInspect), ch1 = p0 action==1 (Inspect),
+          ch2 = p1 action==0 (Comply),     ch3 = p1 action==1 (Violate),
+          ch4 = undetected flag ((NotInspect, Violate))
+        """
+        C = self.n_obs_types
+        v = np.zeros((C,), dtype=np.uint8)
+
+        def set_bits(pid: str, base: int):
+            a = self._last_actions.get(pid, None)
+            if a is None:
+                return
+            if a == 0:
+                v[base + 0] = 1
+            elif a == 1:
+                v[base + 1] = 1
+
+        set_bits("player_0", 0)
+        set_bits("player_1", 2)
+        v[2 * self.n_agents] = 1 if self._last_undetected else 0
+
+        if self.flatten_observations:
+            return v
+        return v.reshape(1, 1, -1)
+
+    # ────────────────────────────────────────────────────────────────────
+    #                          State helpers
+    # ────────────────────────────────────────────────────────────────────
+    @property
+    def state_space(self):
+        C = self.n_obs_types
+        if self.flatten_observations:
+            return Box(low=0, high=1, shape=(C,), dtype=np.uint8)
+        return Box(low=0, high=1, shape=(1, 1, C), dtype=np.uint8)
+
+    def state(self):
+        return self._obs()
+
+    def num_cells(self) -> int:
+        """Number of spatial cells in the layered observation grid.
+
+        InspectionMatrix is non-spatial: the entire game state is a single global cell.
+        This returns 1 regardless of whether observations are flattened or shaped (1, 1, C).
+        """
+        return 1
+
+    def channel_names(self) -> list[str]:
+        """
+        Human-friendly names for each observation channel index.
+
+        By construction in _obs:
+          ch0 = p0 action==0 (NotInspect)
+          ch1 = p0 action==1 (Inspect)
+          ch2 = p1 action==0 (Comply)
+          ch3 = p1 action==1 (Violate)
+          ch4 = undetected flag ((NotInspect, Violate))
+        """
+        names: list[str] = ["" for _ in range(self.n_obs_types)]
+
+        # Player 0 = Inspector
+        if self.n_obs_types > 0:
+            names[0] = "inspector_notinspect"
+        if self.n_obs_types > 1:
+            names[1] = "inspector_inspect"
+
+        # Player 1 = Inspectee
+        if self.n_obs_types > 2:
+            names[2] = "inspectee_comply"
+        if self.n_obs_types > 3:
+            names[3] = "inspectee_violate"
+
+        # Undetected violation flag
+        undetected_idx = 2 * self.n_agents
+        if undetected_idx < self.n_obs_types:
+            names[undetected_idx] = "undetected_violation"
+
+        # Fallback for any unnamed channels (future-proofing)
+        for i, name in enumerate(names):
+            if not name:
+                names[i] = f"channel_{i}"
+
+        return names
+
+    def action_names(self, action: int) -> str:
+        """
+        Human-friendly name for an action integer ID.
+        """
+        action = int(action)
+        if action == int(InspectorActions.NotInspect):
+            return "not_inspect_or_comply"
+        if action == int(InspectorActions.Inspect):
+            return "inspect_or_violate"
+        return f"action_{action}"
+
+    # ────────────────────────────────────────────────────────────────────
+    #               Lightweight state serialization (no deep clone)
+    # ────────────────────────────────────────────────────────────────────
+    def get_state(self):
+        """
+        Tuple layout:
+          (
+            agents: tuple[str, ...],
+            round_no: int,
+            last_actions: tuple[int|None, int|None],  # (p0, p1)
+            last_undetected: bool,
+            cum_rewards: tuple[float, float],         # (p0, p1)
+            rng_state: object
+          )
+        """
+        agents = tuple(self.agents) if getattr(self, "agents", None) is not None else tuple()
+        p0, p1 = self.possible_agents
+        last = (self._last_actions.get(p0, None), self._last_actions.get(p1, None))
+        cum = (float(self._cum_rewards.get(p0, 0.0)), float(self._cum_rewards.get(p1, 0.0)))
+        rng_state = self.rng.get_state()
+        return (agents, int(self._round), last, bool(self._last_undetected), cum, rng_state)
+
+    def set_state(self, state):
+        (agents, round_no, last, last_undetected, cum, rng_state) = state
+
+        self.agents = list(agents)
+        self._round = int(round_no)
+
+        p0, p1 = self.possible_agents
+        if len(last) != 2:
+            raise ValueError(f"InspectionMatrix.set_state: last_actions must be len 2, got {len(last)}")
+        if len(cum) != 2:
+            raise ValueError(f"InspectionMatrix.set_state: cum_rewards must be len 2, got {len(cum)}")
+
+        self._last_actions = {
+            p0: (None if last[0] is None else int(last[0])),
+            p1: (None if last[1] is None else int(last[1])),
+        }
+        self._last_undetected = bool(last_undetected)
+        self._cum_rewards = {p0: float(cum[0]), p1: float(cum[1])}
+
+        if rng_state is not None:
+            self.rng.set_state(rng_state)
+
+    def get_rng_state(self):
+        return self.rng.get_state()
+
+    def set_rng_state(self, rng_state):
+        self.rng.set_state(rng_state)
+
+    def reseed(self, seed: int):
+        self.rng = np.random.RandomState(int(seed))


### PR DESCRIPTION
Added the following repeated matrix games, they are all from the broader game theory literature. All of them have relevant safety properties that can be defined, the environments themselves are fully deterministic but the other agents make it probabilistic.

* `Bertrand:` 2 player game, price-competiton game, also known as the "gas station" game. Shows a price war and has interesting strategies for punishing deviations etc (although doing so is non-Markovian. Under discounting, all of these environments have existence of a stationary (Markovian) mixed (probabilistic) equilibria existence).
* `Chicken:` 2-player game, conflict game, if both are "brave" (compete), they crash (worst outcome); if one swerves ("chicken") and the other doesn't, the non-swerver wins (best), the swerver loses (second-worst); if both swerve, it's a draw (moderate outcome)
* `Congestion:` **n-player game**, 2 parallel roads, taking the most congested one is unfavourable. Congestion games show up in routing/optimisation problems generally.
*  `Dynamic Public Goods Game:` 2-payer game, contribute or withhold to a growing pot, withholding allows free riding from the pot
* `Inspection:` 2-player game, see the payoff matrix for comply-violate and inspect-not inspect. Intuitively, the inspector has a less reward for inspecting when there's no violation, and vice versa.