### PR TITLE
Add central MARL env factory `make_marl_env(...)`

### DIFF
--- a/docs/Environments/Multi Agent/Matrix Games.md
+++ b/docs/Environments/Multi Agent/Matrix Games.md
@@ -17,6 +17,24 @@ from masa.envs.multiagent.matrix.chicken import ChickenMatrix
 env = ChickenMatrix()
 ```
 
+For the standard MASA MARL wrapper stack, create them through `make_marl_env`.
+This applies `LabelledParallelEnv -> ConstrainedMarkovGameEnv` and uses the
+environment's default `label_fn` and `cost_fn` when available:
+
+```python
+from masa.common.constraints.multi_agent.cmg import Budget
+from masa.common.utils import make_marl_env
+
+env = make_marl_env(
+    "chicken_matrix",
+    "cmg",
+    budgets=[Budget(amount=10.0, agents=("player_0", "player_1"), name="shared")],
+)
+```
+
+Registered MARL environment ids are `bertrand_matrix`, `chicken_matrix`,
+`congestion_matrix`, `dpgg_matrix`, and `inspection_matrix`.
+
 ## Available Games
 
 - [Bertrand](Matrix%20Games/Bertrand)

--- a/docs/Get Started/Basic Usage.rst
+++ b/docs/Get Started/Basic Usage.rst
@@ -177,10 +177,12 @@ saving); the snippet mirrors the general style used in MASA runs.
        stats_window_size=100,        # optional
    )
 
-API Reference for :func:`~masa.common.utils.make_env`
+API Reference for environment factories
 ---------------------------------------
 
 .. autofunction:: masa.common.utils.make_env
+
+.. autofunction:: masa.common.utils.make_marl_env
 
 Next Steps
 ----------

--- a/masa/common/labelled_pz_env.py
+++ b/masa/common/labelled_pz_env.py
@@ -11,27 +11,57 @@ class LabelledParallelEnv(ParallelEnv):
 
     def __init__(self, env: ParallelEnv, label_fn: Dict[str, LabelFn] | LabelFn):
         self.env = env
-        self.agents = env.possible_agents
+        self.metadata = getattr(env, "metadata", self.metadata)
+        self.agents = list(getattr(env, "agents", env.possible_agents))
         self.label_fn = label_fn
         self.cost_fn = getattr(env, "cost_fn", None)
 
+    def __getattr__(self, name: str):
+        if name == "env":
+            raise AttributeError(name)
+        return getattr(self.env, name)
+
     def reset(self, seed: int | None = None, options: Dict[str, Any] | None = None):
         obs, info = self.env.reset(seed=seed, options=options)
+        self.agents = list(getattr(self.env, "agents", self.possible_agents))
         for a in obs:
             lf = self.label_fn[a] if isinstance(self.label_fn, dict) else self.label_fn
-            info.setdefault(a, {})["labels"] = set(lf(obs[a]))
+            agent_info = info.setdefault(a, {})
+            if agent_info is None:
+                agent_info = {}
+                info[a] = agent_info
+            agent_info["labels"] = set(lf(obs[a]))
         return obs, info
 
     def step(self, actions):
         obs, rewards, term, trunc, infos = self.env.step(actions)
-        # compute labels and cost per agent, update shared constraint using a simple merge
+        self.agents = list(getattr(self.env, "agents", self.possible_agents))
         for a in obs:
             lf = self.label_fn[a] if isinstance(self.label_fn, dict) else self.label_fn
             labels = set(lf(obs[a]))
-            infos.setdefault(a, {})["labels"] = labels
+            agent_info = infos.setdefault(a, {})
+            if agent_info is None:
+                agent_info = {}
+                infos[a] = agent_info
+            agent_info["labels"] = labels
 
         return obs, rewards, term, trunc, infos
 
     @property
     def possible_agents(self):
         return self.env.possible_agents
+
+    def observation_space(self, agent):
+        return self.env.observation_space(agent)
+
+    def action_space(self, agent):
+        return self.env.action_space(agent)
+
+    def state(self):
+        return self.env.state()
+
+    def render(self):
+        return self.env.render()
+
+    def close(self):
+        return self.env.close()

--- a/masa/common/registry.py
+++ b/masa/common/registry.py
@@ -29,5 +29,7 @@ class Registry:
 
 
 ENV_REGISTRY = Registry()
+MARL_ENV_REGISTRY = Registry()
 ALGO_REGISTRY = Registry()
 CONSTRAINT_REGISTRY = Registry()
+MARL_CONSTRAINT_REGISTRY = Registry()

--- a/masa/common/utils.py
+++ b/masa/common/utils.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
-from typing import Optional
+from typing import Any, Optional
 import importlib
 import warnings
+from pettingzoo import ParallelEnv
 from masa.plugins.helpers import load_plugins
-from masa.common.registry import ENV_REGISTRY, CONSTRAINT_REGISTRY
+from masa.common.registry import (
+    CONSTRAINT_REGISTRY,
+    ENV_REGISTRY,
+    MARL_CONSTRAINT_REGISTRY,
+    MARL_ENV_REGISTRY,
+)
 from masa.common.wrappers import TimeLimit, ConstraintMonitor, RewardMonitor
 from masa.common.labelled_env import LabelledEnv
+from masa.common.labelled_pz_env import LabelledParallelEnv
 from masa.common.label_fn import LabelFn
 
 def load_callable(path: str):
@@ -89,3 +96,64 @@ def make_env(
     env = RewardMonitor(env)
     return env
 
+
+def make_marl_env(
+    env_id: str,
+    constraint: str,
+    *,
+    label_fn: Optional[dict[str, LabelFn] | LabelFn] = None,
+    env_kwargs: Optional[dict[str, Any]] = None,
+    **constraint_kwargs,
+) -> ParallelEnv:
+    r"""
+    Construct a fully wrapped MASA multi-agent environment.
+
+    This helper creates a PettingZoo parallel environment and applies the
+    standard MARL wrapper order:
+
+    :class:`~masa.common.labelled_pz_env.LabelledParallelEnv` :math:`\rightarrow`
+    :class:`~masa.common.constraints.multi_agent.cmg.ConstrainedMarkovGameEnv`
+
+    Args:
+        env_id:
+            Multi-agent environment identifier registered in ``MARL_ENV_REGISTRY``.
+        constraint:
+            Multi-agent constraint identifier registered in
+            ``MARL_CONSTRAINT_REGISTRY``.
+        label_fn:
+            Optional labelling function, or per-agent mapping of labelling
+            functions. If omitted, the base environment's ``label_fn`` attribute
+            is used.
+        env_kwargs:
+            Optional keyword arguments forwarded to the base environment
+            constructor.
+        **constraint_kwargs:
+            Additional keyword arguments forwarded to the constraint wrapper
+            constructor. If ``cost_fn`` is omitted and the base environment
+            exposes one, it is forwarded automatically.
+
+    Returns:
+        A wrapped PettingZoo parallel environment compatible with MASA MARL
+        constraints.
+    """
+
+    load_plugins()
+    env_ctor = MARL_ENV_REGISTRY.get(env_id)
+    constraint_ctor = MARL_CONSTRAINT_REGISTRY.get(constraint)
+
+    raw_env = env_ctor(**dict(env_kwargs or {}))
+    resolved_label_fn = label_fn if label_fn is not None else getattr(raw_env, "label_fn", None)
+    if resolved_label_fn is None:
+        raise ValueError(
+            f"MARL env '{env_id}' does not expose a default label_fn. "
+            "Pass label_fn=... to make_marl_env."
+        )
+
+    if "cost_fn" not in constraint_kwargs:
+        cost_fn = getattr(raw_env, "cost_fn", None)
+        if cost_fn is not None:
+            constraint_kwargs["cost_fn"] = cost_fn
+
+    env = LabelledParallelEnv(raw_env, resolved_label_fn)
+    env = constraint_ctor(env, **constraint_kwargs)
+    return env

--- a/masa/plugins/supported.py
+++ b/masa/plugins/supported.py
@@ -1,4 +1,10 @@
-from masa.common.registry import ENV_REGISTRY, CONSTRAINT_REGISTRY, ALGO_REGISTRY
+from masa.common.registry import (
+    ALGO_REGISTRY,
+    CONSTRAINT_REGISTRY,
+    ENV_REGISTRY,
+    MARL_CONSTRAINT_REGISTRY,
+    MARL_ENV_REGISTRY,
+)
 
 # Register supported envs
 ENV_REGISTRY.register("cont_cartpole", "masa.envs.continuous.cartpole:ContinuousCartPole")
@@ -18,12 +24,22 @@ ENV_REGISTRY.register("bridge_crossing", "masa.envs.tabular.bridge_crossing:Brid
 ENV_REGISTRY.register("bridge_crossing_v2", "masa.envs.tabular.bridge_crossing_v2:BridgeCrossingV2")
 ENV_REGISTRY.register("media_streaming", "masa.envs.tabular.media_streaming:MediaStreaming")
 
+# Register supported multi-agent envs
+MARL_ENV_REGISTRY.register("bertrand_matrix", "masa.envs.multiagent.matrix.bertrand:BertrandMatrix")
+MARL_ENV_REGISTRY.register("chicken_matrix", "masa.envs.multiagent.matrix.chicken:ChickenMatrix")
+MARL_ENV_REGISTRY.register("congestion_matrix", "masa.envs.multiagent.matrix.congestion:CongestionMatrix")
+MARL_ENV_REGISTRY.register("dpgg_matrix", "masa.envs.multiagent.matrix.dpgg:DPGGMatrix")
+MARL_ENV_REGISTRY.register("inspection_matrix", "masa.envs.multiagent.matrix.inspection:InspectionMatrix")
+
 # Register supported constraints
 CONSTRAINT_REGISTRY.register("cmdp", "masa.common.constraints.cmdp:CumulativeCostEnv")
 CONSTRAINT_REGISTRY.register("prob", "masa.common.constraints.prob:ProbabilisticSafetyEnv")
 CONSTRAINT_REGISTRY.register("reach_avoid", "masa.common.constraints.reach_avoid:ReachAvoidEnv")
 CONSTRAINT_REGISTRY.register("ltl_safety", "masa.common.constraints.ltl_safety:LTLSafetyEnv")
 CONSTRAINT_REGISTRY.register("pctl", "masa.common.constraints.pctl:PCTLEnv")
+
+# Register supported multi-agent constraints
+MARL_CONSTRAINT_REGISTRY.register("cmg", "masa.common.constraints.multi_agent.cmg:ConstrainedMarkovGameEnv")
 
 # Register supported algorithms
 ALGO_REGISTRY.register("q_learning", "masa.algorithms.tabular:QL")

--- a/tests/test_cmg.py
+++ b/tests/test_cmg.py
@@ -65,3 +65,49 @@ def test_constrained_markov_game_env_tracks_overlapping_budgets():
     assert episode_metrics["solo_satisfied"] == pytest.approx(1.0)
     assert episode_metrics["shared_satisfied"] == pytest.approx(0.0)
     assert episode_metrics["satisfied"] == pytest.approx(0.0)
+
+
+def test_marl_envs_are_registered():
+    from masa.plugins.helpers import load_plugins
+    from masa.common.registry import MARL_CONSTRAINT_REGISTRY, MARL_ENV_REGISTRY
+
+    load_plugins()
+
+    assert MARL_ENV_REGISTRY.get("bertrand_matrix").__name__ == "BertrandMatrix"
+    assert MARL_ENV_REGISTRY.get("chicken_matrix").__name__ == "ChickenMatrix"
+    assert MARL_ENV_REGISTRY.get("congestion_matrix").__name__ == "CongestionMatrix"
+    assert MARL_ENV_REGISTRY.get("dpgg_matrix").__name__ == "DPGGMatrix"
+    assert MARL_ENV_REGISTRY.get("inspection_matrix").__name__ == "InspectionMatrix"
+    assert MARL_CONSTRAINT_REGISTRY.get("cmg").__name__ == "ConstrainedMarkovGameEnv"
+
+
+def test_make_marl_env_uses_central_wrapper_path():
+    from masa.common.utils import make_marl_env
+
+    env = make_marl_env(
+        "chicken_matrix",
+        "cmg",
+        env_kwargs={"max_moves": 1},
+        budgets=[Budget(amount=1.5, agents=("player_0", "player_1"), name="shared")],
+    )
+
+    assert isinstance(env, ConstrainedMarkovGameEnv)
+    assert isinstance(env.env, LabelledParallelEnv)
+    assert env.env.label_fn is label_fn
+    assert env.cost_fn is cost_fn
+
+    obs, infos = env.reset(seed=0)
+
+    assert set(obs) == {"player_0", "player_1"}
+    assert infos["player_0"]["labels"] == set()
+    assert infos["player_1"]["labels"] == set()
+
+    _, _, _, truncations, infos = env.step(
+        {"player_0": Actions.Straight, "player_1": Actions.Straight}
+    )
+
+    assert truncations["player_0"] is True
+    assert truncations["player_1"] is True
+    assert "unsafe" in infos["player_0"]["labels"]
+    assert "unsafe" in infos["player_1"]["labels"]
+    assert env.constraint_step_metrics()["shared_cost"] == pytest.approx(2.0)


### PR DESCRIPTION
Adds a central MASA wrapper path (`make_marl_env(...)`) for multi-agent PettingZoo environments, basically matching the existing single-agent `make_env` flow.
