### PR TITLE
Add frozenlake

### DIFF
--- a/docs/Tutorials/Shielding.md
+++ b/docs/Tutorials/Shielding.md
@@ -4,6 +4,7 @@ These tutorials show how MASA shielding wrappers turn safety analysis into envir
 
 - [Probabilistic Shielding MiniPacman](Shielding/Probabilistic%20Shielding%20MiniPacman) builds a PCTL-constrained MiniPacman environment, wraps it with `ProbShieldWrapperDisc`, and inspects safety bounds, successor dynamics, and projected safe actions.
 - [Safety Abstractions Pacman Coins](Shielding/Safety%20Abstractions%20Pacman%20Coins) shows why structured Pacman coin observations need a discrete safety abstraction before probabilistic shielding can compute safety bounds.
+- [FrozenLake Shielding](Shielding/FrozenLake%20Shielding) shows how the same discrete shield synthesis path applies to Gymnasium-style FrozenLake dynamics.
 
 Runnable notebooks:
 
@@ -16,4 +17,5 @@ Runnable notebooks:
 
 Shielding/Probabilistic Shielding MiniPacman
 Shielding/Safety Abstractions Pacman Coins
+Shielding/FrozenLake Shielding
 ```

--- a/docs/Tutorials/Shielding/FrozenLake Shielding.md
+++ b/docs/Tutorials/Shielding/FrozenLake Shielding.md
@@ -1,0 +1,54 @@
+# FrozenLake Shielding
+
+This tutorial-style note shows how FrozenLake can be used with MASA's existing discrete probabilistic shield. FrozenLake is a small discrete MDP with known transition probabilities, so shield synthesis can run directly over the environment's exact transition matrix.
+
+## Build The Environment
+
+```python
+from masa.common.utils import make_env
+
+env = make_env(
+    "FrozenLake",
+    "PCTL",
+    100,
+    env_kwargs={"is_slippery": False},
+    constraint_kwargs={"alpha": 0.01},
+)
+```
+
+The default FrozenLake safety property labels hole tiles as `"hole"` and assigns cost `1.0` to those labels. Start, frozen, and goal tiles are labelled as `"start"`, `"frozen"`, and `"goal"`.
+
+## Add The Shield
+
+```python
+from masa.prob_shield.prob_shield_wrapper_v1 import ProbShieldWrapperDisc
+
+shielded_env = ProbShieldWrapperDisc(
+    env,
+    init_safety_bound=1e-12,
+    theta=1e-12,
+    max_vi_steps=2_000,
+    granularity=10,
+)
+```
+
+During construction, `ProbShieldWrapperDisc` reads FrozenLake's transition matrix, computes reach-hole safety bounds with interval value iteration, and augments the Gymnasium interface with a remaining safety budget.
+
+After reset:
+
+```python
+obs, info = shielded_env.reset(seed=0)
+
+obs["orig_obs"]       # original FrozenLake state id
+obs["safety_bound"]  # remaining probability budget for reaching a hole
+```
+
+The shielded action format is the same as other discrete probabilistic shields:
+
+```text
+[primary_action, fallback_action, beta_0, beta_1, ..., beta_K]
+```
+
+The wrapper projects the proposed action onto a safe distribution over FrozenLake's original actions before stepping the base environment.
+
+Runnable example: `masa/examples/prob_shield_frozen_lake_example.py`.

--- a/masa/common/utils.py
+++ b/masa/common/utils.py
@@ -177,8 +177,10 @@ def make_env(
     constraint_kwargs = dict(constraint_kwargs or {})
     if "cost_fn" not in constraint_kwargs:
         cost_fn = getattr(env, "cost_fn", None)
+        if cost_fn is None:
+            cost_fn = getattr(env.unwrapped, "cost_fn", None)
         if cost_fn is not None:
-            constraint_kwargs["cost_fn"] = costfn
+            constraint_kwargs["cost_fn"] = cost_fn
     env = constraint_ctor(env, **constraint_kwargs)
     env = ConstraintMonitor(env)
     env = RewardMonitor(env)

--- a/masa/configs/envs/FrozenLake.yaml
+++ b/masa/configs/envs/FrozenLake.yaml
@@ -1,0 +1,17 @@
+defaults:
+  env:
+    id: FrozenLake
+    max_episode_steps: 100
+    label_fn: masa.envs.tabular.frozen_lake:label_fn
+    cost_fn: masa.envs.tabular.frozen_lake:cost_fn
+
+  constraint:
+    type: PCTL
+    alpha: 0.01
+
+  run:
+    total_timesteps: 100000
+    eval_every: 10000
+    eval_episodes: 10
+    log_every: 10000
+    stats_window_size: 100

--- a/masa/envs/__init__.py
+++ b/masa/envs/__init__.py
@@ -116,6 +116,11 @@ registry.ENV_REGISTRY.register(
 )
 
 registry.ENV_REGISTRY.register(
+    "FrozenLake",
+    "masa.envs.tabular.frozen_lake:FrozenLake",
+)
+
+registry.ENV_REGISTRY.register(
     "MediaStreaming",
     "masa.envs.tabular.media_streaming:MediaStreaming",
 )

--- a/masa/envs/tabular/frozen_lake.py
+++ b/masa/envs/tabular/frozen_lake.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Sequence
+
+import numpy as np
+from gymnasium.envs.toy_text.frozen_lake import (
+    FrozenLakeEnv as GymFrozenLakeEnv,
+    generate_random_map,
+)
+
+
+DEFAULT_DESC = (
+    "SFFF",
+    "FHFH",
+    "FFFH",
+    "HFFG",
+)
+
+TILE_LABELS = {
+    "S": {"start"},
+    "F": {"frozen"},
+    "H": {"hole"},
+    "G": {"goal"},
+}
+
+
+def _normalize_desc(desc: Sequence[str] | np.ndarray | None) -> np.ndarray:
+    if desc is None:
+        desc = DEFAULT_DESC
+    return np.asarray(desc, dtype="c")
+
+
+def _tile_at(desc: Sequence[str] | np.ndarray, obs: int) -> str:
+    flat_desc = _normalize_desc(desc).ravel()
+    return bytes(flat_desc[int(obs)]).decode("utf-8")
+
+
+def label_fn(obs: int) -> set[str]:
+    """Default 4x4 FrozenLake labelling function."""
+    return set(TILE_LABELS.get(_tile_at(DEFAULT_DESC, int(obs)), set()))
+
+
+def cost_fn(labels: Iterable[str]) -> float:
+    return 1.0 if "hole" in labels else 0.0
+
+
+def _states_with_tile(desc: np.ndarray, tile: str) -> list[int]:
+    return [
+        int(i)
+        for i, cell in enumerate(desc.ravel())
+        if bytes(cell).decode("utf-8") == tile
+    ]
+
+
+def _build_transition_matrix(
+    transition_table: dict[int, dict[int, list[tuple[float, int, float, bool]]]],
+    n_states: int,
+    n_actions: int,
+) -> np.ndarray:
+    matrix = np.zeros((n_states, n_states, n_actions), dtype=np.float64)
+    for state in range(n_states):
+        for action in range(n_actions):
+            for probability, next_state, _, _ in transition_table[state][action]:
+                matrix[int(next_state), state, action] += float(probability)
+    return matrix
+
+
+class FrozenLake(GymFrozenLakeEnv):
+    """MASA-compatible FrozenLake environment with exact discrete dynamics.
+
+    This class preserves Gymnasium's FrozenLake transition and rendering
+    behavior while exposing a transition matrix and safety labels for MASA's
+    discrete shield synthesis wrappers.
+    """
+
+    def __init__(
+        self,
+        render_mode: str | None = None,
+        desc: Sequence[str] | None = None,
+        map_name: str | None = "4x4",
+        is_slippery: bool = True,
+        success_rate: float = 1.0 / 3.0,
+        reward_schedule: tuple[float, float, float] = (1, 0, 0),
+    ):
+        super().__init__(
+            render_mode=render_mode,
+            desc=desc,
+            map_name=map_name,
+            is_slippery=is_slippery,
+            success_rate=success_rate,
+            reward_schedule=reward_schedule,
+        )
+
+        self._n_states = int(self.observation_space.n)
+        self._n_actions = int(self.action_space.n)
+        self._nrow, self._ncol = self.desc.shape
+        self._grid_size = self._nrow
+
+        self._start_state = int(np.flatnonzero(self.initial_state_distrib)[0])
+        self._hole_states = _states_with_tile(self.desc, "H")
+        self._goal_states = _states_with_tile(self.desc, "G")
+        self._terminal_states = self._hole_states + self._goal_states
+
+        self._transition_matrix = _build_transition_matrix(
+            self.P,
+            self._n_states,
+            self._n_actions,
+        )
+        self._successor_states = None
+        self._transition_probs = None
+
+    def label_fn(self, obs: int) -> set[str]:
+        return set(TILE_LABELS.get(_tile_at(self.desc, int(obs)), set()))
+
+    def cost_fn(self, labels: Iterable[str]) -> float:
+        return cost_fn(labels)
+
+    @property
+    def has_transition_matrix(self) -> bool:
+        return self._transition_matrix is not None
+
+    @property
+    def has_successor_states_dict(self) -> bool:
+        return False
+
+    def get_transition_matrix(self) -> np.ndarray:
+        return self._transition_matrix
+
+    def get_successor_states_dict(self):
+        return None
+
+    def render(self) -> Any:
+        if self.render_mode is None:
+            return None
+        return super().render()
+
+
+__all__ = [
+    "FrozenLake",
+    "cost_fn",
+    "generate_random_map",
+    "label_fn",
+]

--- a/masa/examples/prob_shield_frozen_lake_example.py
+++ b/masa/examples/prob_shield_frozen_lake_example.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import numpy as np
+
+from masa.common.utils import make_env
+from masa.prob_shield.prob_shield_wrapper_v1 import ProbShieldWrapperDisc
+
+
+def build_env():
+    return make_env(
+        "FrozenLake",
+        "PCTL",
+        100,
+        env_kwargs={"is_slippery": False},
+        constraint_kwargs={"alpha": 0.01},
+    )
+
+
+def main():
+    env = ProbShieldWrapperDisc(
+        build_env(),
+        init_safety_bound=1e-12,
+        theta=1e-12,
+        max_vi_steps=2_000,
+        granularity=10,
+    )
+
+    obs, info = env.reset(seed=0)
+    print("Initial observation:", obs)
+    print("Initial labels:", info["labels"])
+    print("Initial safety lower bound:", env.safety_lb[env._current_obs])
+    print("Max successors:", env.max_successors)
+
+    action = np.zeros(2 + env.max_successors, dtype=np.int64)
+    action[0] = 2  # right
+    action[1] = 1  # down
+
+    safe_actions, bounds, proj_penalty, margin_penalty = env._project_act(*env._parse_act(action))
+    print("Projected action distribution:", safe_actions)
+    print("Projected successor bounds:", bounds)
+    print("Projection penalty:", proj_penalty)
+    print("Margin penalty:", margin_penalty)
+
+    next_obs, reward, terminated, truncated, info = env.step(action)
+    print("Next observation:", next_obs)
+    print("Reward:", reward)
+    print("Terminated:", terminated)
+    print("Truncated:", truncated)
+    print("Constraint info:", info["constraint"])
+
+    env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_frozen_lake_shield.py
+++ b/tests/test_frozen_lake_shield.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def test_frozen_lake_is_registered_and_labels_default_map():
+    import masa
+    from gymnasium import spaces
+    from masa.common.registry import ENV_REGISTRY
+    from masa.envs.tabular.frozen_lake import FrozenLake, cost_fn, label_fn
+
+    del masa
+
+    assert ENV_REGISTRY.get("FrozenLake").__name__ == "FrozenLake"
+
+    env = FrozenLake(is_slippery=False)
+    assert isinstance(env.observation_space, spaces.Discrete)
+    assert isinstance(env.action_space, spaces.Discrete)
+    assert env.observation_space.n == 16
+    assert env.action_space.n == 4
+    assert env.label_fn(0) == {"start"}
+    assert env.label_fn(1) == {"frozen"}
+    assert env.label_fn(5) == {"hole"}
+    assert env.label_fn(15) == {"goal"}
+    assert label_fn(5) == {"hole"}
+    assert cost_fn({"hole"}) == 1.0
+    assert cost_fn({"frozen"}) == 0.0
+    env.close()
+
+
+def test_frozen_lake_transition_matrix_matches_deterministic_actions():
+    from masa.envs.tabular.frozen_lake import FrozenLake
+
+    env = FrozenLake(is_slippery=False)
+    matrix = env.get_transition_matrix()
+
+    assert env.has_transition_matrix is True
+    assert env.has_successor_states_dict is False
+    assert env.get_successor_states_dict() is None
+    assert matrix.shape == (16, 16, 4)
+    np.testing.assert_allclose(matrix.sum(axis=0), 1.0)
+
+    assert matrix[0, 0, 0] == 1.0  # left into boundary
+    assert matrix[4, 0, 1] == 1.0  # down
+    assert matrix[1, 0, 2] == 1.0  # right
+    assert matrix[0, 0, 3] == 1.0  # up into boundary
+    env.close()
+
+
+def test_frozen_lake_transition_matrix_aggregates_slippery_duplicates():
+    from masa.envs.tabular.frozen_lake import FrozenLake
+
+    env = FrozenLake(is_slippery=True, success_rate=1.0 / 3.0)
+    matrix = env.get_transition_matrix()
+
+    np.testing.assert_allclose(matrix.sum(axis=0), 1.0)
+    np.testing.assert_allclose(matrix[0, 0, 0], 2.0 / 3.0)
+    np.testing.assert_allclose(matrix[4, 0, 0], 1.0 / 3.0)
+    np.testing.assert_allclose(matrix[0, 0, 3], 2.0 / 3.0)
+    np.testing.assert_allclose(matrix[1, 0, 3], 1.0 / 3.0)
+    env.close()
+
+
+def test_frozen_lake_accepts_gymnasium_variants_and_custom_desc():
+    from masa.envs.tabular.frozen_lake import FrozenLake
+
+    large_env = FrozenLake(map_name="8x8", is_slippery=True, success_rate=0.9)
+    assert large_env.observation_space.n == 64
+    large_env.close()
+
+    random_env = FrozenLake(map_name=None, is_slippery=False)
+    assert random_env.observation_space.n == 64
+    random_env.close()
+
+    custom_env = FrozenLake(
+        desc=["SF", "HG"],
+        is_slippery=False,
+        success_rate=0.8,
+        reward_schedule=(2.0, -1.0, 0.0),
+    )
+    assert custom_env.observation_space.n == 4
+    assert custom_env.label_fn(2) == {"hole"}
+    assert custom_env.label_fn(3) == {"goal"}
+
+    obs, _ = custom_env.reset(seed=0)
+    assert obs == 0
+    obs, reward, terminated, truncated, _ = custom_env.step(1)
+    assert obs == 2
+    assert reward == -1.0
+    assert terminated is True
+    assert truncated is False
+    custom_env.close()
+
+
+def test_frozen_lake_make_env_uses_default_labels_and_costs():
+    from masa.common.utils import make_env
+
+    env = make_env(
+        "FrozenLake",
+        "PCTL",
+        100,
+        env_kwargs={"is_slippery": False},
+        constraint_kwargs={"alpha": 0.01},
+    )
+
+    obs, info = env.reset(seed=0)
+    assert obs == 0
+    assert info["labels"] == {"start"}
+    assert info["constraint"]["type"] == "PCTL"
+    assert info["constraint"]["step"]["cost"] == 0.0
+
+    env.close()
+
+
+def test_frozen_lake_prob_shield_constructs_and_steps():
+    from masa.common.utils import make_env
+    from masa.prob_shield.prob_shield_wrapper_v1 import ProbShieldWrapperDisc
+
+    env = make_env(
+        "FrozenLake",
+        "PCTL",
+        100,
+        env_kwargs={"is_slippery": False},
+        constraint_kwargs={"alpha": 0.01},
+    )
+    shielded_env = ProbShieldWrapperDisc(
+        env,
+        init_safety_bound=1e-12,
+        theta=1e-12,
+        max_vi_steps=2_000,
+        granularity=10,
+    )
+
+    obs, info = shielded_env.reset(seed=0)
+    assert set(obs) == {"orig_obs", "safety_bound"}
+    assert obs["orig_obs"] == 0
+    assert info["labels"] == {"start"}
+
+    action = np.zeros(2 + shielded_env.max_successors, dtype=np.int64)
+    action[0] = 2
+    action[1] = 1
+
+    next_obs, reward, terminated, truncated, info = shielded_env.step(action)
+    assert set(next_obs) == {"orig_obs", "safety_bound"}
+    assert shielded_env._orig_obs_space.contains(next_obs["orig_obs"])
+    assert reward in (0.0, 1.0)
+    assert isinstance(terminated, bool)
+    assert isinstance(truncated, bool)
+    assert "proj_penalty" in info
+    assert "margin_penalty" in info
+
+    shielded_env.close()


### PR DESCRIPTION
## Summary

Adds MASA support for discrete safety shield synthesis on Gymnasium FrozenLake environment.

This PR introduces a registered `FrozenLake` tabular environment that mirrors Gymnasium’s `FrozenLake-v1`, exposes an exact transition matrix for `ProbShieldWrapperDisc`, and labels hole states as unsafe by default. It also adds a shielding example, docs, config, and focused tests.

## Changes

- Add `masa.envs.tabular.frozen_lake.FrozenLake`
  - Supports `4x4`, `8x8`, custom `desc`, `is_slippery`, `success_rate`, and `reward_schedule`
  - Converts Gymnasium’s transition table into MASA’s `(next_state, current_state, action)` transition tensor
  - Exposes default `label_fn` and `cost_fn` where holes are unsafe

- Register `FrozenLake` in MASA’s environment registry
- Add `masa/configs/envs/FrozenLake.yaml`
- Add `masa/examples/prob_shield_frozen_lake_example.py`
- Add FrozenLake shielding docs and link them from the Shielding tutorial index
- Fix `make_env` cost-function forwarding typo:
  - `costfn` -> `cost_fn`
  - Adds fallback lookup through `env.unwrapped.cost_fn`

## Testing

- Added focused FrozenLake shield tests covering:
  - registry lookup
  - labels and costs
  - deterministic and slippery transition matrices
  - Gymnasium constructor variants
  - `make_env` integration
  - `ProbShieldWrapperDisc` construction and step behavior

- Ran:
  - `python -m compileall ...` successfully

- Could not run full pytest locally because `uv run pytest ...` fails dependency resolution on this platform due to unavailable `tensorflow==2.21.0` wheels for `macosx_26_0_x86_64`.