### PR TITLE
Add arguments to control MDP's stochasticity

### DIFF
--- a/masa/envs/tabular/bridge_crossing.py
+++ b/masa/envs/tabular/bridge_crossing.py
@@ -16,7 +16,7 @@ GRID = np.arange(GRID_SIZE**2).reshape(GRID_SIZE, GRID_SIZE)
 START_STATE = int(GRID[-1, 0])
 GOAL_STATES = list(GRID[:7, :].flatten())
 LAVA_STATES = list(GRID[8:12, :8].flatten()) + list(GRID[8:12, -9:].flatten())
-SLIP_PROB = 0.04
+DEFAULT_SLIP_PROBABILITY = 0.04
 TERMINAL_STATES = GOAL_STATES + LAVA_STATES
 
 LABEL_DICT = defaultdict(set)
@@ -30,13 +30,13 @@ label_fn = lambda obs: LABEL_DICT[obs]
 
 cost_fn = lambda labels: 1.0 if "lava" in labels else 0.0
 
-@lru_cache(maxsize=1)
-def get_transition_matrix():
+@lru_cache(maxsize=None)
+def get_transition_matrix(slip_prob: float = DEFAULT_SLIP_PROBABILITY):
     return create_transition_matrix(
         GRID_SIZE, 
         N_STATES,
         N_ACTIONS,
-        slip_prob=SLIP_PROB,
+        slip_prob=slip_prob,
         terminal_states=TERMINAL_STATES
     )
 
@@ -47,9 +47,16 @@ class BridgeCrossing(TabularEnv):
         self,
         render_mode: Literal["ansi", "rgb_array", "human"] | None = None,
         render_window_size: int = 512,
+        slip_prob: float = DEFAULT_SLIP_PROBABILITY
     ):
         super().__init__()
         validate_renderer_options(render_mode, render_window_size)
+
+        if not 0.0 <= slip_prob <= 1.0:
+            raise ValueError(
+                f"slip_prob must be in [0, 1], got {slip_prob}"
+            )
+        self._slip_prob = float(slip_prob)
 
         self._grid_size = GRID_SIZE
         self._ncol = self._grid_size
@@ -67,7 +74,7 @@ class BridgeCrossing(TabularEnv):
 
         self._terminal_states = TERMINAL_STATES
 
-        self._transition_matrix = get_transition_matrix()
+        self._transition_matrix = get_transition_matrix(slip_prob=self._slip_prob)
 
         self.np_random = None
         self._state = None
@@ -118,3 +125,6 @@ class BridgeCrossing(TabularEnv):
 
     def handle_pygame_event(self, event: Any) -> bool:
         return self._renderer.handle_pygame_event(event)
+    
+    def get_transition_matrix(self):
+        return self._transition_matrix

--- a/masa/envs/tabular/bridge_crossing_v2.py
+++ b/masa/envs/tabular/bridge_crossing_v2.py
@@ -16,7 +16,7 @@ GRID = np.arange(GRID_SIZE**2).reshape(GRID_SIZE, GRID_SIZE)
 START_STATE = int(GRID[-1, 0])
 GOAL_STATES = list(GRID[:7, :].flatten())
 LAVA_STATES = list(GRID[8:12, 2:16].flatten()) + list([GRID[11, 1]])
-SLIP_PROB = 0.04
+DEFAULT_SLIP_PROBABILITY = 0.04
 TERMINAL_STATES = GOAL_STATES + LAVA_STATES
 
 LABEL_DICT = defaultdict(set)
@@ -30,13 +30,13 @@ label_fn = lambda obs: LABEL_DICT[obs]
 
 cost_fn = lambda labels: 1.0 if "lava" in labels else 0.0
 
-@lru_cache(maxsize=1)
-def get_transition_matrix():
+@lru_cache(maxsize=None)
+def get_transition_matrix(slip_prob: float = DEFAULT_SLIP_PROBABILITY):
     return create_transition_matrix(
         GRID_SIZE, 
         N_STATES,
         N_ACTIONS,
-        slip_prob=SLIP_PROB,
+        slip_prob=slip_prob,
         terminal_states=TERMINAL_STATES
     )
 
@@ -47,9 +47,16 @@ class BridgeCrossingV2(TabularEnv):
         self,
         render_mode: Literal["ansi", "rgb_array", "human"] | None = None,
         render_window_size: int = 512,
+        slip_prob: float = DEFAULT_SLIP_PROBABILITY
     ):
         super().__init__()
         validate_renderer_options(render_mode, render_window_size)
+
+        if not 0.0 <= slip_prob <= 1.0:
+            raise ValueError(
+                f"slip_prob must be in [0, 1], got {slip_prob}"
+            )
+        self._slip_prob = float(slip_prob)
 
         self._grid_size = GRID_SIZE
         self._ncol = self._grid_size
@@ -67,7 +74,7 @@ class BridgeCrossingV2(TabularEnv):
 
         self._terminal_states = TERMINAL_STATES
 
-        self._transition_matrix = get_transition_matrix()
+        self._transition_matrix = get_transition_matrix(slip_prob=self._slip_prob)
 
         self.np_random = None
         self._state = None
@@ -118,3 +125,6 @@ class BridgeCrossingV2(TabularEnv):
 
     def handle_pygame_event(self, event: Any) -> bool:
         return self._renderer.handle_pygame_event(event)
+
+    def get_transition_matrix(self):
+        return self._transition_matrix

--- a/masa/envs/tabular/colour_bomb_grid_world.py
+++ b/masa/envs/tabular/colour_bomb_grid_world.py
@@ -19,7 +19,7 @@ BLUE_STATES = [9, 10, 18, 19]
 PINK_STATES = [7, 8, 16, 17]
 WALL_STATES = [11, 12, 13, 14, 15, 29, 30, 50, 52, 53, 55, 56, 57, 59, 64, 66, 69]
 BOMB_STATES = [27, 43, 78]
-SLIP_PROB = 0.1
+DEFAULT_SLIP_PROBABILITY = 0.1
 GOAL_STATES = YELLOW_STATES + BLUE_STATES + PINK_STATES
 
 LABEL_DICT = defaultdict(set)
@@ -39,13 +39,13 @@ label_fn = lambda obs: LABEL_DICT[obs]
 
 cost_fn = lambda labels: 1.0 if "bomb" in labels else 0.0
 
-@lru_cache(maxsize=1)
-def get_transition_matrix():
+@lru_cache(maxsize=None)
+def get_transition_matrix(slip_prob: float = DEFAULT_SLIP_PROBABILITY):
     return create_transition_matrix(
         GRID_SIZE, 
         N_STATES,
         N_ACTIONS,
-        slip_prob=SLIP_PROB,
+        slip_prob=slip_prob,
         terminal_states=GOAL_STATES,
         wall_states=WALL_STATES
     )
@@ -57,9 +57,16 @@ class ColourBombGridWorld(TabularEnv):
         self,
         render_mode: Literal["ansi", "rgb_array", "human"] | None = None,
         render_window_size: int = 512,
+        slip_prob: float = DEFAULT_SLIP_PROBABILITY,
     ):
         super().__init__()
         validate_renderer_options(render_mode, render_window_size)
+
+        if not 0.0 <= slip_prob <= 1.0:
+            raise ValueError(
+                f"slip_prob must be in [0, 1], got {slip_prob}"
+            )
+        self._slip_prob = float(slip_prob)
 
         self._grid_size = GRID_SIZE
         self._ncol = self._grid_size
@@ -84,7 +91,7 @@ class ColourBombGridWorld(TabularEnv):
         self._goal_states = GOAL_STATES
         self._active_colour_dict = {}
 
-        self._transition_matrix = get_transition_matrix()
+        self._transition_matrix = get_transition_matrix(self._slip_prob)
 
         self.np_random = None
         self._state = None
@@ -133,3 +140,6 @@ class ColourBombGridWorld(TabularEnv):
 
     def handle_pygame_event(self, event: Any) -> bool:
         return self._renderer.handle_pygame_event(event)
+    
+    def get_transition_matrix(self):
+        return self._transition_matrix

--- a/masa/envs/tabular/colour_bomb_grid_world_v2.py
+++ b/masa/envs/tabular/colour_bomb_grid_world_v2.py
@@ -27,7 +27,7 @@ WALL_STATES = [45,60,75,210,195,180,165,150, 142] + \
     [87,72,57,70,55,39,9,13,14,29,44,59]
 BOMB_STATES = [76, 181, 123,82,207,8,58]
 MEDIC_STATES = [154, 93, 38, 205, 74]
-SLIP_PROB = 0.1
+DEFAULT_SLIP_PROBABILITY = 0.1
 GOAL_STATES = GREEN_STATES + YELLOW_STATES + RED_STATES + BLUE_STATES + PINK_STATES
 
 LABEL_DICT = defaultdict(set)
@@ -52,13 +52,13 @@ label_fn = lambda obs: LABEL_DICT[obs]
 
 cost_fn = lambda labels: 1.0 if "bomb" in labels else 0.0
 
-@lru_cache(maxsize=1)
-def get_transition_matrix():
+@lru_cache(maxsize=None)
+def get_transition_matrix(slip_prob: float = DEFAULT_SLIP_PROBABILITY):
     return create_transition_matrix(
         GRID_SIZE, 
         N_STATES,
         N_ACTIONS,
-        slip_prob=SLIP_PROB,
+        slip_prob=slip_prob,
         safe_states=MEDIC_STATES,
         terminal_states=GOAL_STATES,
         wall_states=WALL_STATES
@@ -71,9 +71,16 @@ class ColourBombGridWorldV2(TabularEnv):
         self,
         render_mode: Literal["ansi", "rgb_array", "human"] | None = None,
         render_window_size: int = 512,
+        slip_prob: float = DEFAULT_SLIP_PROBABILITY,
     ):
         super().__init__()
         validate_renderer_options(render_mode, render_window_size)
+        
+        if not 0.0 <= slip_prob <= 1.0:
+            raise ValueError(
+                f"slip_prob must be in [0, 1], got {slip_prob}"
+            )
+        self._slip_prob = float(slip_prob)
 
         self._grid_size = GRID_SIZE
         self._ncol = self._grid_size
@@ -99,7 +106,7 @@ class ColourBombGridWorldV2(TabularEnv):
         self._safe_states = MEDIC_STATES
         self._active_colour_dict = {}
 
-        self._transition_matrix = get_transition_matrix()
+        self._transition_matrix = get_transition_matrix(slip_prob=self._slip_prob)
 
         # after reaching a goal state, transition to a random start state
         for _state in self._goal_states:
@@ -155,3 +162,6 @@ class ColourBombGridWorldV2(TabularEnv):
 
     def handle_pygame_event(self, event: Any) -> bool:
         return self._renderer.handle_pygame_event(event)
+    
+    def get_transition_matrix(self):
+        return self._transition_matrix

--- a/masa/envs/tabular/colour_bomb_grid_world_v3.py
+++ b/masa/envs/tabular/colour_bomb_grid_world_v3.py
@@ -42,7 +42,7 @@ for i in range(N_COLOURED_ZONES):
         [87,72,57,70,55,39,9,13,14,29,44,59]) + z)
     BOMB_STATES += list(np.array([76, 181, 123,82,207,8,58]) + z)
     MEDIC_STATES += list(np.array([154, 93, 38, 205, 74]) + z)
-SLIP_PROB = 0.1
+DEFAULT_SLIP_PROBABILITY = 0.1
 GOAL_STATES = GREEN_STATES + YELLOW_STATES + RED_STATES + BLUE_STATES + PINK_STATES
 
 LABEL_DICT = defaultdict(set)
@@ -67,15 +67,15 @@ label_fn = lambda obs: LABEL_DICT[obs]
 
 cost_fn = lambda labels: 1.0 if "bomb" in labels else 0.0
 
-@lru_cache(maxsize=1)
-def get_transition_matrix():
+@lru_cache(maxsize=None)
+def get_transition_matrix(slip_prob: float = DEFAULT_SLIP_PROBABILITY):
     return create_advanced_transition_matrix(
         GRID_SIZE,
         N_COLOURED_ZONES,
         N_STATES,
         N_ACTIONS,
         GOAL_STATES,
-        slip_prob=SLIP_PROB,
+        slip_prob=slip_prob,
         safe_states=MEDIC_STATES,
         wall_states=WALL_STATES
     )
@@ -87,9 +87,16 @@ class ColourBombGridWorldV3(TabularEnv):
         self,
         render_mode: Literal["ansi", "rgb_array", "human"] | None = None,
         render_window_size: int = 512,
+        slip_prob: float = DEFAULT_SLIP_PROBABILITY,
     ):
         super().__init__()
         validate_renderer_options(render_mode, render_window_size)
+
+        if not 0.0 <= slip_prob <= 1.0:
+            raise ValueError(
+                f"slip_prob must be in [0, 1], got {slip_prob}"
+            )
+        self._slip_prob = float(slip_prob)
 
         self._grid_size = GRID_SIZE
         self._ncol = self._grid_size
@@ -126,7 +133,7 @@ class ColourBombGridWorldV3(TabularEnv):
 
         self._safe_states = MEDIC_STATES
 
-        self._transition_matrix = get_transition_matrix()
+        self._transition_matrix = get_transition_matrix(slip_prob=self._slip_prob)
 
         # after reaching a goal state, transition to a random start state
         for _state in self._goal_states:
@@ -182,3 +189,6 @@ class ColourBombGridWorldV3(TabularEnv):
 
     def handle_pygame_event(self, event: Any) -> bool:
         return self._renderer.handle_pygame_event(event)
+    
+    def get_transition_matrix(self):
+        return self._transition_matrix

--- a/masa/envs/tabular/colour_grid_world.py
+++ b/masa/envs/tabular/colour_grid_world.py
@@ -17,7 +17,7 @@ GOAL_STATE = 80
 BLUE_STATE = 36
 GREEN_STATE = 40
 PURPLE_STATE = 4
-SLIP_PROB = 0.1
+DEFAULT_SLIP_PROBABILITY = 0.1
 
 LABEL_DICT = defaultdict(set)
 LABEL_DICT[START_STATE] = {"start"}
@@ -30,13 +30,13 @@ label_fn = lambda obs: LABEL_DICT[obs]
 
 cost_fn = lambda labels: 1.0 if "blue" in labels else 0.0
 
-@lru_cache(maxsize=1)
-def get_transition_matrix():
+@lru_cache(maxsize=None)
+def get_transition_matrix(slip_prob: float = DEFAULT_SLIP_PROBABILITY):
     return create_transition_matrix(
         GRID_SIZE,
         N_STATES,
         N_ACTIONS,
-        slip_prob=SLIP_PROB,
+        slip_prob=slip_prob,
         terminal_states=[GOAL_STATE]
     )
 
@@ -47,9 +47,16 @@ class ColourGridWorld(TabularEnv):
         self,
         render_mode: Literal["ansi", "rgb_array", "human"] | None = None,
         render_window_size: int = 512,
+        slip_prob: float = DEFAULT_SLIP_PROBABILITY
     ):
         super().__init__()
         validate_renderer_options(render_mode, render_window_size)
+
+        if not 0.0 <= slip_prob <= 1.0:
+            raise ValueError(
+                f"slip_prob must be in [0, 1], got {slip_prob}"
+            )
+        self._slip_prob = slip_prob
 
         self._grid_size = GRID_SIZE
         self._ncol = self._grid_size
@@ -67,7 +74,7 @@ class ColourGridWorld(TabularEnv):
         self._green_state = GREEN_STATE
         self._purple_state = PURPLE_STATE
 
-        self._transition_matrix = get_transition_matrix()
+        self._transition_matrix = get_transition_matrix(self._slip_prob)
 
         self.np_random = None
         self._state = None
@@ -116,3 +123,6 @@ class ColourGridWorld(TabularEnv):
 
     def handle_pygame_event(self, event: Any) -> bool:
         return self._renderer.handle_pygame_event(event)
+    
+    def get_transition_matrix(self):
+        return self._transition_matrix


### PR DESCRIPTION
## Summary

Adds configurable stochasticity controls to the tabular grid-world environments by exposing a `slip_prob` argument on environment initialization.

## Changes

- Replaces fixed `SLIP_PROB` constants with `DEFAULT_SLIP_PROBABILITY`.
- Adds a `slip_prob` constructor argument to:
  - `BridgeCrossing`
  - `BridgeCrossingV2`
  - `ColourGridWorld`
  - `ColourBombGridWorld`
  - `ColourBombGridWorldV2`
  - `ColourBombGridWorldV3`
- Validates that `slip_prob` is between `0.0` and `1.0`.
- Updates transition matrix generation to use the provided stochasticity value.
- Expands transition matrix caching so different `slip_prob` values are cached separately.
- Adds instance-level `get_transition_matrix()` helpers for accessing the configured transition matrix.

## Motivation

This makes environment stochasticity configurable without changing the default behaviour. Existing callers continue to use the same slip probabilities, while experiments can now vary transition noise directly through environment arguments.

## Testing

Not run.